### PR TITLE
KRBN-5234: misleading error message when the failure is caused by wrong credentials

### DIFF
--- a/pkg/nutanix/client.go
+++ b/pkg/nutanix/client.go
@@ -253,8 +253,11 @@ func CheckResponse(r *http.Response) error {
 		return nil
 	}
 
-	pretty, _ := json.MarshalIndent(errRes, "", "  ")
-	return fmt.Errorf("error: %s", string(pretty))
+	pretty, err := json.MarshalIndent(errRes, "", "  ")
+	if err != nil {
+		return fmt.Errorf("status: %s, error-response: %+v, marshal error: %v", r.Status, errRes, err)
+	}
+	return fmt.Errorf("status: %s, error-response: %s", r.Status, string(pretty))
 }
 
 // ErrorResponse ...
@@ -270,7 +273,7 @@ type ErrorResponse struct {
 type MessageResource struct {
 
 	// Custom key-value details relevant to the status.
-	Details map[string]interface{} `json:"details,omitempty"`
+	Details interface{} `json:"details,omitempty"`
 
 	// If state is ERROR, a message describing the error.
 	Message string `json:"message"`

--- a/pkg/nutanix/v3/v3_structs.go
+++ b/pkg/nutanix/v3/v3_structs.go
@@ -294,7 +294,7 @@ type VMIntentInput struct {
 type MessageResource struct {
 
 	// Custom key-value details relevant to the status.
-	Details map[string]string `json:"details,omitempty"`
+	Details interface{} `json:"details,omitempty"`
 
 	// If state is ERROR, a message describing the error.
 	Message *string `json:"message"`


### PR DESCRIPTION
Fix for KRBN-5234: misleading error message when the failure is caused by wrong credentials