### PR TITLE
Removing debug messages

### DIFF
--- a/pkg/nutanix/client.go
+++ b/pkg/nutanix/client.go
@@ -571,7 +571,6 @@ func CheckResponse(r *http.Response) error {
 	if err != nil {
 		return fmt.Errorf("unmarshalling error response %s for response body %s", err, string(buf))
 	}
-	log.Print("[DEBUG] after json.Unmarshal")
 
 	errRes := &ErrorResponse{}
 	if status, ok := res["status"]; ok {
@@ -587,11 +586,9 @@ func CheckResponse(r *http.Response) error {
 		return nil
 	}
 
-	log.Print("[DEBUG] after bunch of switch cases")
 	if err != nil {
 		return err
 	}
-	log.Print("[DEBUG] first nil check")
 
 	// karbon error check
 	if messageInfo, ok := res["message_info"]; ok {
@@ -607,7 +604,6 @@ func CheckResponse(r *http.Response) error {
 		return nil
 	}
 
-	log.Print("[DEBUG] after errRes.State")
 	pretty, err := json.MarshalIndent(errRes, "", "  ")
 	if err != nil {
 		return fmt.Errorf("status: %s, error-response: %+v, marshal error: %v", r.Status, errRes, err)


### PR DESCRIPTION
Removing debug messages from prism-go-client to have cleaner outputs.