### PR TITLE
Modify makefile action for better linting annotations

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -1,4 +1,4 @@
-name: Makefile CI
+name: Build, Lint, and Test
 env:
   EXPORT_RESULT: true
 on:
@@ -26,8 +26,13 @@ jobs:
     - name: Check build
       run: make build
 
-    - name: Check linting
-      run: make lint
+    - name: Run golangci-lint
+      uses: golangci/golangci-lint-action@v3.2.0
+      with:
+        args: --enable gofmt --enable gofumpt
+
+    - name: Check YAML linting
+      run: make lint-yaml
 
     - name: Run tests
       run: make test

--- a/v3/v3_structs.go
+++ b/v3/v3_structs.go
@@ -1629,7 +1629,6 @@ type Metadata struct {
 	// CategoriesMapping    map[string][]string `json:"categories_mapping,omitempty" mapstructure:"categories_mapping,omitempty"`
 	// EntityVersion        *string             `json:"entity_version,omitempty" mapstructure:"entity_version,omitempty"`
 	// UseCategoriesMapping *bool               `json:"use_categories_mapping,omitempty" mapstructure:"use_categories_mapping,omitempty"`
-
 }
 
 // NetworkSecurityRuleIntentInput An intentful representation of a network_security_rule


### PR DESCRIPTION
- Use official golangci-lint action for go annotations
- Use make lint-yaml instead of make lint to avoid duplicate failures