### PR TITLE
Read secret keys on demand to tolerate symlinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - v3 client constructor now takes functional options as parameters
 - v3 client constructor returns error instead of failing silently
 - Add context to v3 interface method parameters to explicitly propagate context
+- Bugfix in secretdir environment provider for tolerating symlinks
 
 ### Removed
 - remove internal.NewBaseClient constructor


### PR DESCRIPTION
Kubernetes secret mount directory contains symlinks not regular files. A
symlink can point to file or directory and it takes extra effort to distinguish
between the two cases.
Since we read from an in-memory filesystem we can just do extra file IO
w/o worrying about performance.
    
k8s secrets keys show up as symlinks not regular files when mounted inside
a container.
