### PR TITLE
Add Key to the NutanixTrustBundleReference struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add `AdditionalTrustBundle` property to the `NutanixPrismEndpoint` struct in environment/credential/types.go
 - Add `AdditionalTrustBundle` property to the `ManagementEndpoint` struct in environment/types/types/go
+- Add `Key` to the `AdditionalTrustBundle` struct to denote the key in the config map carrying the cert chain.
 
 ### Changed
 - Add license header to generated file and add a makefile target for generate

--- a/environment/credentials/types.go
+++ b/environment/credentials/types.go
@@ -92,12 +92,19 @@ type NutanixTrustBundleReference struct {
 	// +kubebuilder:validation:Enum=String,Secret,ConfigMap
 	Kind NutanixTrustBundleKind `json:"kind"`
 	// Data of the trust bundle if Kind is String.
+	// +kubebuilder:validation:Type=string
 	// +optional
 	Data string `json:"data"`
+	// Key in the ConfigMap if the type is ConfigMap
+	// +kubebuilder:validation:Type=string
+	// +optional
+	Key string `json:"key"`
 	// Name of the credential.
+	// +kubebuilder:validation:Type=string
 	// +optional
 	Name string `json:"name"`
 	// namespace of the credential.
+	// +kubebuilder:validation:Type=string
 	// +optional
 	Namespace string `json:"namespace"`
 }

--- a/environment/providers/kubernetes/kubernetes.go
+++ b/environment/providers/kubernetes/kubernetes.go
@@ -31,7 +31,7 @@ func (prov *provider) getAdditionalTrustBundle() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return cm.Data["ca.crt"], nil
+	return cm.Data[trustBundleRef.Key], nil
 }
 
 func (prov *provider) getCredentials(_ types.Topology) (*types.ApiCredentials, error) {


### PR DESCRIPTION
Key specifies the key in the ConfigMap. Earlier, `ca.crt` was being
hardcoded as the expected key.