### PR TITLE
Fix indentation in Build, Lint, Test Action

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -35,7 +35,7 @@ jobs:
       run: make lint-yaml
 
     - name: Check Kubebuilder Annotation linting
-        run: make lint-kubebuilder
+      run: make lint-kubebuilder
 
     - name: Run tests
       run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+SHELL := /bin/bash
 GOCMD=go
 GOTEST=$(GOCMD) test
 GOVET=$(GOCMD) vet
@@ -39,7 +40,6 @@ CONTROLLER_GEN_BIN := controller-gen
 CONTROLLER_GEN := $(TOOLS_BIN_DIR)/$(CONTROLLER_GEN_BIN)
 # CRD_OPTIONS define options to add to the CONTROLLER_GEN
 CRD_OPTIONS ?= "crd:crdVersions=v1"
-
 
 $(TOOLS_BIN_DIR):
 	mkdir -p $(TOOLS_BIN_DIR)


### PR DESCRIPTION
An Older PR https://github.com/nutanix-cloud-native/prism-go-client/pull/42 that introduced the kubebuilder step had incorrect indentation and as a result the action is not running on the repo at all (failing silently). The `SHELL` has been explicitly set to `/bin/bash` to ensure we use `bash` instead of `sh` to run the `go-get-tool` embedded script in Makefile.

**How was this change tested?**
The Build, Lint, and Test action is running on this PR.

