### PR TITLE
Bugfix: Stop base64 decoding ConfigMap.BinaryData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.3.4] - 2022-11-24
+### Changed
+- Bugfix: Stop explicit base64 decoding of BinaryData from ConfigMap in Kubernetes env provider
+
 ## [0.3.3] - 2022-11-24
 ### Changed
 - Kubernetes env provider can now read the trust bundle from both BinaryData and Data

--- a/environment/providers/kubernetes/kubernetes.go
+++ b/environment/providers/kubernetes/kubernetes.go
@@ -5,7 +5,6 @@
 package kubernetes
 
 import (
-	"encoding/base64"
 	"fmt"
 	"net/url"
 
@@ -40,11 +39,7 @@ func (prov *provider) getAdditionalTrustBundle() (string, error) {
 		return cert, nil
 	}
 	if b64Cert, ok := cm.BinaryData[certBundleKey]; ok {
-		cert, err := base64.StdEncoding.DecodeString(string(b64Cert))
-		if err != nil {
-			return "", err
-		}
-		return string(cert), nil
+		return string(b64Cert), nil
 	}
 	return "", nil
 }


### PR DESCRIPTION
Ensure Kubernetes env provider does not decode binary data as base64.

**How was this tested?**
The unit test was updated to rely on kubernetes apimachinery pkg to handle BinaryData appropriately.
Earlier the test was relying on the clientset API to handle BinaryData appropriately and that did not work as I originally expected it to.