### PR TITLE
Ensure port is explicitly provided in the local environment provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Local environment provider now fetches port from `NUTANIX_PORT` environment variable
+
 ## [0.3.4] - 2022-11-24
 ### Changed
 - Bugfix: Stop explicit base64 decoding of BinaryData from ConfigMap in Kubernetes env provider

--- a/environment/providers/local/local.go
+++ b/environment/providers/local/local.go
@@ -18,6 +18,7 @@ import (
 
 const (
 	endpointEnv    = "NUTANIX_ENDPOINT"
+	portEnv        = "NUTANIX_PORT"
 	userEnv        = "NUTANIX_USERNAME"
 	passwordEnv    = "NUTANIX_PASSWORD"
 	insecureEnv    = "NUTANIX_INSECURE"
@@ -35,10 +36,15 @@ func (prov *provider) GetManagementEndpoint(
 	if endpoint == "" {
 		return nil, types.ErrNotFound
 	}
-	if !strings.HasPrefix(endpoint, "https://") {
-		endpoint = fmt.Sprintf("https://%s", endpoint)
+	port := os.Getenv(portEnv)
+	if port == "" {
+		port = "9440"
 	}
-	addr, err := url.Parse(endpoint)
+	address := fmt.Sprintf("%s:%s", endpoint, port)
+	if !strings.HasPrefix(address, "https://") {
+		address = fmt.Sprintf("https://%s", address)
+	}
+	addr, err := url.Parse(address)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Earlier the provider relied on the port being part of the endpoint which is not consistent with our usage in Cluster API Provider for Nutanix.