### PR TITLE
Add codecov action to build-lint-test workflow

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -42,3 +42,7 @@ jobs:
 
     - name: Prepare coverage report
       run: make coverage
+
+    - name: Codecov
+      uses: codecov/codecov-action@v3.1.1
+


### PR DESCRIPTION
This is to upload our code coverage reports to codecov.