### PR TITLE
Add unit tests for cluster registration API methods in Karbon package

### DIFF
--- a/karbon/karbon_cluster_registration_service_test.go
+++ b/karbon/karbon_cluster_registration_service_test.go
@@ -25,8 +25,8 @@ func validateK8sClusterRegistration(t *testing.T, k8sClusterReg *K8sClusterRegis
 	assert.NotEmpty(t, *k8sClusterReg.Name)
 	assert.NotEmpty(t, k8sClusterReg.Status)
 	assert.NotEmpty(t, k8sClusterReg.UUID)
-	//assert.NotEmpty(t, k8sClusterReg.CategoriesMapping)
-	//assert.NotZero(t, k8sClusterReg.CategoriesMapping)
+	assert.NotEmpty(t, k8sClusterReg.CategoriesMapping)
+	assert.NotZero(t, k8sClusterReg.CategoriesMapping)
 }
 
 func validateK8sClusterRegistrationGetResponse(t *testing.T, expected_k8s_cluster_name, expected_k8s_cluster_uuid string,
@@ -122,7 +122,7 @@ func TestKarbonCreateClusterRegistrationWithNoCategory(t *testing.T) {
 	require.NoError(t, err)
 
 	kctx := mock.NewContext(mock.Config{
-		Mode: keploy.MODE_RECORD,
+		Mode: keploy.MODE_TEST,
 		Name: t.Name(),
 	})
 
@@ -164,7 +164,7 @@ func TestKarbonCreateClusterRegistrationWithNoUUID(t *testing.T) {
 	require.NoError(t, err)
 
 	kctx := mock.NewContext(mock.Config{
-		Mode: keploy.MODE_RECORD,
+		Mode: keploy.MODE_TEST,
 		Name: t.Name(),
 	})
 

--- a/karbon/karbon_cluster_registration_service_test.go
+++ b/karbon/karbon_cluster_registration_service_test.go
@@ -87,19 +87,15 @@ func TestKarbonCreateClusterRegistration(t *testing.T) {
 	test_metadata_apiversion := "v1.1.0"
 	test_metadata := &Metadata{APIVersion: &test_metadata_apiversion}
 
-	t.Log("Get Cluster registration")
 	responseGetReg, err := nkeClient.ClusterRegistrationOperations.GetK8sRegistration(kctx, test_cluster_uuid)
 	if err == nil {
-		t.Log("Get Cluster registration exists")
 		validateK8sClusterRegistrationGetResponse(t, test_cluster_name, test_cluster_uuid, responseGetReg)
 		// Registration exists. delete it so that we can create it
-		t.Log("Delete Cluster registration")
 		responseDelReg, err := nkeClient.ClusterRegistrationOperations.DeleteK8sRegistration(kctx, test_cluster_uuid)
 		assert.NoError(t, err)
 		validateK8sClusterRegistrationDeleteResponse(t, test_cluster_name, test_cluster_uuid, responseDelReg)
 	}
 
-	t.Log("Create Cluster registration")
 	createRequest := &K8sCreateClusterRegistrationRequest{
 		Name:              &test_cluster_name,
 		UUID:              test_cluster_uuid,
@@ -131,19 +127,15 @@ func TestKarbonCreateClusterRegistrationWithNoCategory(t *testing.T) {
 	test_metadata_apiversion := "v1.1.0"
 	test_metadata := &Metadata{APIVersion: &test_metadata_apiversion}
 
-	t.Log("Get Cluster registration")
 	responseGetReg, err := nkeClient.ClusterRegistrationOperations.GetK8sRegistration(kctx, test_cluster_uuid)
 	if err == nil {
-		t.Log("Get Cluster registration exists")
 		validateK8sClusterRegistrationGetResponse(t, test_cluster_name, test_cluster_uuid, responseGetReg)
 		// Registration exists. delete it so that we can create it
-		t.Log("Delete Cluster registration")
 		responseDelReg, err := nkeClient.ClusterRegistrationOperations.DeleteK8sRegistration(kctx, test_cluster_uuid)
 		assert.NoError(t, err)
 		validateK8sClusterRegistrationDeleteResponse(t, test_cluster_name, test_cluster_uuid, responseDelReg)
 	}
 
-	t.Log("Create Cluster registration")
 	createRequest := &K8sCreateClusterRegistrationRequest{
 		Name:     &test_cluster_name,
 		UUID:     test_cluster_uuid,
@@ -176,7 +168,6 @@ func TestKarbonCreateClusterRegistrationWithNoUUID(t *testing.T) {
 	test_metadata_apiversion := "v1.1.0"
 	test_metadata := &Metadata{APIVersion: &test_metadata_apiversion}
 
-	t.Log("Create Cluster registration")
 	createRequest := &K8sCreateClusterRegistrationRequest{
 		Name:              &test_cluster_name,
 		CategoriesMapping: test_category_mapping,
@@ -200,7 +191,6 @@ func TestKarbonGetK8sRegistrationList(t *testing.T) {
 		Mode: keploy.MODE_TEST,
 		Name: t.Name(),
 	})
-	t.Log("Get Cluster registration List")
 	// returns type K8sCreateClusterRegistrationResponse
 	response, err := nkeClient.ClusterRegistrationOperations.GetK8sRegistrationList(kctx)
 	assert.NoError(t, err)

--- a/karbon/karbon_cluster_registration_service_test.go
+++ b/karbon/karbon_cluster_registration_service_test.go
@@ -16,8 +16,8 @@ import (
 )
 
 const (
-	NoCategoryMappingErrorMsg = "No category mappings provided"
-	NoUUIDErrorMsg            = "uuid in body is required"
+	noCategoryMappingErrorMsg = "No category mappings provided"
+	noUUIDErrorMsg            = "uuid in body is required"
 )
 
 func validateK8sClusterRegistration(t *testing.T, k8sClusterReg *K8sClusterRegistration) {
@@ -144,7 +144,7 @@ func TestKarbonCreateClusterRegistrationWithNoCategory(t *testing.T) {
 	// check if the error is expected
 	_, err = nkeClient.ClusterRegistrationOperations.CreateK8sRegistration(kctx, createRequest)
 	if assert.Error(t, err) {
-		assert.Contains(t, fmt.Sprint(err), NoCategoryMappingErrorMsg)
+		assert.Contains(t, fmt.Sprint(err), noCategoryMappingErrorMsg)
 	}
 }
 
@@ -176,7 +176,7 @@ func TestKarbonCreateClusterRegistrationWithNoUUID(t *testing.T) {
 	// check if the error is expected
 	_, err = nkeClient.ClusterRegistrationOperations.CreateK8sRegistration(kctx, createRequest)
 	if assert.Error(t, err) {
-		assert.Contains(t, fmt.Sprint(err), NoUUIDErrorMsg)
+		assert.Contains(t, fmt.Sprint(err), noUUIDErrorMsg)
 	}
 }
 

--- a/karbon/karbon_cluster_registration_service_test.go
+++ b/karbon/karbon_cluster_registration_service_test.go
@@ -1,6 +1,7 @@
 package karbon
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -15,16 +16,17 @@ import (
 	"github.com/nutanix-cloud-native/prism-go-client/internal/testhelpers"
 )
 
+var (
+	NoCategoryMappingError = errors.New("error: map[Cluster Create:Failed to validate the category mapping. No category mappings provided.]")
+	NoUUIDError            = errors.New("error: uuid in body is required")
+)
+
 func validateK8sClusterRegistration(t *testing.T, k8sClusterReg *K8sClusterRegistration) {
 	assert.NotEmpty(t, *k8sClusterReg.Name)
 	assert.NotEmpty(t, k8sClusterReg.Status)
 	assert.NotEmpty(t, k8sClusterReg.UUID)
-	// TODO(deepakm-ntnx) enable following code once the crash is fixed
-	// assert.NotEmpty(t, k8sClusterReg.Identity.Name)
-	// assert.NotEmpty(t, *k8sClusterReg.Identity.Kind)
-	// assert.NotEmpty(t, *k8sClusterReg.Identity.UUID)
-	assert.NotEmpty(t, k8sClusterReg.CategoriesMapping)
-	assert.NotZero(t, k8sClusterReg.CategoriesMapping)
+	//assert.NotEmpty(t, k8sClusterReg.CategoriesMapping)
+	//assert.NotZero(t, k8sClusterReg.CategoriesMapping)
 }
 
 func validateK8sClusterRegistrationGetResponse(t *testing.T, expected_k8s_cluster_name, expected_k8s_cluster_uuid string,
@@ -35,12 +37,7 @@ func validateK8sClusterRegistrationGetResponse(t *testing.T, expected_k8s_cluste
 	assert.NotEmpty(t, responseGetReg.Status)
 	assert.NotEmpty(t, responseGetReg.UUID)
 	assert.Equal(t, expected_k8s_cluster_uuid, responseGetReg.UUID)
-	// TODO(deepakm-ntnx) enable following code once the crash is fixed
-	// assert.NotEmpty(t, responseGetReg.Identity.Name)
-	// assert.NotEmpty(t, *responseGetReg.Identity.Kind)
-	// assert.NotEmpty(t, *responseGetReg.Identity.UUID)
-	// TODO(deepakm-ntnx) Currently API still allows to pass empty mappings. internal tracker filed
-	// assert.NotZero(t, len(responseGetReg.CategoriesMapping))
+	assert.NotZero(t, len(responseGetReg.CategoriesMapping))
 }
 
 func validateK8sClusterRegistrationDeleteResponse(t *testing.T, expected_k8s_cluster_name, expected_k8s_cluster_uuid string,
@@ -116,6 +113,81 @@ func TestKarbonCreateClusterRegistration(t *testing.T) {
 	validateK8sClusterRegistrationCreateResponse(t, test_cluster_name, test_cluster_uuid, responseCreateReg)
 
 	// TODO get task uuid status
+}
+
+func TestKarbonCreateClusterRegistrationWithNoCategory(t *testing.T) {
+	interceptor := khttpclient.NewInterceptor(http.DefaultTransport)
+	creds := testhelpers.CredentialsFromEnvironment(t)
+	nkeClient, err := NewKarbonAPIClient(creds, WithRoundTripper(interceptor))
+	require.NoError(t, err)
+
+	kctx := mock.NewContext(mock.Config{
+		Mode: keploy.MODE_RECORD,
+		Name: t.Name(),
+	})
+
+	test_cluster_name := strings.ToLower("cluster2")
+	test_cluster_uuid := strings.ToLower("E33FD0FD-5673-45FA-825D-7EF869A91577")
+	test_metadata_apiversion := "v1.1.0"
+	test_metadata := &Metadata{APIVersion: &test_metadata_apiversion}
+
+	t.Log("Get Cluster registration")
+	responseGetReg, err := nkeClient.ClusterRegistrationOperations.GetK8sRegistration(kctx, test_cluster_uuid)
+	if err == nil {
+		t.Log("Get Cluster registration exists")
+		validateK8sClusterRegistrationGetResponse(t, test_cluster_name, test_cluster_uuid, responseGetReg)
+		// Registration exists. delete it so that we can create it
+		t.Log("Delete Cluster registration")
+		responseDelReg, err := nkeClient.ClusterRegistrationOperations.DeleteK8sRegistration(kctx, test_cluster_uuid)
+		assert.NoError(t, err)
+		validateK8sClusterRegistrationDeleteResponse(t, test_cluster_name, test_cluster_uuid, responseDelReg)
+	}
+
+	t.Log("Create Cluster registration")
+	createRequest := &K8sCreateClusterRegistrationRequest{
+		Name:     &test_cluster_name,
+		UUID:     test_cluster_uuid,
+		Metadata: test_metadata,
+	}
+
+	// check if the error is expected
+	_, err = nkeClient.ClusterRegistrationOperations.CreateK8sRegistration(kctx, createRequest)
+	if assert.Error(t, err) {
+		assert.Equal(t, NoCategoryMappingError, err)
+	}
+}
+
+func TestKarbonCreateClusterRegistrationWithNoUUID(t *testing.T) {
+	interceptor := khttpclient.NewInterceptor(http.DefaultTransport)
+	creds := testhelpers.CredentialsFromEnvironment(t)
+	nkeClient, err := NewKarbonAPIClient(creds, WithRoundTripper(interceptor))
+	require.NoError(t, err)
+
+	kctx := mock.NewContext(mock.Config{
+		Mode: keploy.MODE_RECORD,
+		Name: t.Name(),
+	})
+
+	test_cluster_name := strings.ToLower("cluster3")
+	test_category_mapping := map[string]string{
+		fmt.Sprintf("kubernetes-io-cluster-%s", test_cluster_name): "owned",
+		"KubernetesClusterName": test_cluster_name,
+	}
+	test_metadata_apiversion := "v1.1.0"
+	test_metadata := &Metadata{APIVersion: &test_metadata_apiversion}
+
+	t.Log("Create Cluster registration")
+	createRequest := &K8sCreateClusterRegistrationRequest{
+		Name:              &test_cluster_name,
+		CategoriesMapping: test_category_mapping,
+		Metadata:          test_metadata,
+	}
+
+	// check if the error is expected
+	_, err = nkeClient.ClusterRegistrationOperations.CreateK8sRegistration(kctx, createRequest)
+	if assert.Error(t, err) {
+		assert.Equal(t, NoUUIDError, err)
+	}
 }
 
 func TestKarbonGetK8sRegistrationList(t *testing.T) {

--- a/karbon/karbon_cluster_registration_service_test.go
+++ b/karbon/karbon_cluster_registration_service_test.go
@@ -1,7 +1,6 @@
 package karbon
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -16,9 +15,9 @@ import (
 	"github.com/nutanix-cloud-native/prism-go-client/internal/testhelpers"
 )
 
-var (
-	NoCategoryMappingError = errors.New("error: map[Cluster Create:Failed to validate the category mapping. No category mappings provided.]")
-	NoUUIDError            = errors.New("error: uuid in body is required")
+const (
+	NoCategoryMappingErrorMsg = "No category mappings provided"
+	NoUUIDErrorMsg            = "uuid in body is required"
 )
 
 func validateK8sClusterRegistration(t *testing.T, k8sClusterReg *K8sClusterRegistration) {
@@ -145,7 +144,7 @@ func TestKarbonCreateClusterRegistrationWithNoCategory(t *testing.T) {
 	// check if the error is expected
 	_, err = nkeClient.ClusterRegistrationOperations.CreateK8sRegistration(kctx, createRequest)
 	if assert.Error(t, err) {
-		assert.Equal(t, NoCategoryMappingError, err)
+		assert.Contains(t, fmt.Sprint(err), NoCategoryMappingErrorMsg)
 	}
 }
 
@@ -177,7 +176,7 @@ func TestKarbonCreateClusterRegistrationWithNoUUID(t *testing.T) {
 	// check if the error is expected
 	_, err = nkeClient.ClusterRegistrationOperations.CreateK8sRegistration(kctx, createRequest)
 	if assert.Error(t, err) {
-		assert.Equal(t, NoUUIDError, err)
+		assert.Contains(t, fmt.Sprint(err), NoUUIDErrorMsg)
 	}
 }
 

--- a/karbon/mocks/TestKarbonCreateClusterRegistration.yaml
+++ b/karbon/mocks/TestKarbonCreateClusterRegistration.yaml
@@ -8,7 +8,7 @@ spec:
         Proto: HTTP/1.1
         ProtoMajor: "1"
         ProtoMinor: "1"
-        URL: https://10.45.30.138:9440/karbon/v1-alpha.1/k8s/cluster-registrations/634f5852-ce1b-465c-a95a-9b8dffbdde42
+        URL: https://prism-test.nutanix.com:9440/karbon/v1-alpha.1/k8s/cluster-registrations/634f5852-ce1b-465c-a95a-9b8dffbdde42
         name: http-client
         operation: GET
         type: HTTP_CLIENT
@@ -16,7 +16,7 @@ spec:
         method: GET
         proto_major: 1
         proto_minor: 1
-        url: https://10.45.30.138:9440/karbon/v1-alpha.1/k8s/cluster-registrations/634f5852-ce1b-465c-a95a-9b8dffbdde42
+        url: https://prism-test.nutanix.com:9440/karbon/v1-alpha.1/k8s/cluster-registrations/634f5852-ce1b-465c-a95a-9b8dffbdde42
         header:
             Accept: application/json
             Content-Type: application/json
@@ -63,7 +63,7 @@ spec:
         Proto: HTTP/1.1
         ProtoMajor: "1"
         ProtoMinor: "1"
-        URL: https://10.45.30.138:9440/karbon/v1-alpha.1/k8s/cluster-registrations/634f5852-ce1b-465c-a95a-9b8dffbdde42
+        URL: https://prism-test.nutanix.com:9440/karbon/v1-alpha.1/k8s/cluster-registrations/634f5852-ce1b-465c-a95a-9b8dffbdde42
         name: http-client
         operation: DELETE
         type: HTTP_CLIENT
@@ -71,7 +71,7 @@ spec:
         method: DELETE
         proto_major: 1
         proto_minor: 1
-        url: https://10.45.30.138:9440/karbon/v1-alpha.1/k8s/cluster-registrations/634f5852-ce1b-465c-a95a-9b8dffbdde42
+        url: https://prism-test.nutanix.com:9440/karbon/v1-alpha.1/k8s/cluster-registrations/634f5852-ce1b-465c-a95a-9b8dffbdde42
         header:
             Accept: application/json
             Content-Type: application/json
@@ -119,7 +119,7 @@ spec:
         Proto: HTTP/1.1
         ProtoMajor: "1"
         ProtoMinor: "1"
-        URL: https://10.45.30.138:9440/karbon/v1-alpha.1/k8s/cluster-registrations/
+        URL: https://prism-test.nutanix.com:9440/karbon/v1-alpha.1/k8s/cluster-registrations/
         name: http-client
         operation: POST
         type: HTTP_CLIENT
@@ -127,7 +127,7 @@ spec:
         method: POST
         proto_major: 1
         proto_minor: 1
-        url: https://10.45.30.138:9440/karbon/v1-alpha.1/k8s/cluster-registrations/
+        url: https://prism-test.nutanix.com:9440/karbon/v1-alpha.1/k8s/cluster-registrations/
         header:
             Accept: application/json
             Content-Type: application/json

--- a/karbon/mocks/TestKarbonCreateClusterRegistrationWithNoCategory.yaml
+++ b/karbon/mocks/TestKarbonCreateClusterRegistrationWithNoCategory.yaml
@@ -1,0 +1,111 @@
+version: api.keploy.io/v1beta2
+kind: Http
+name: TestKarbonCreateClusterRegistrationWithNoCategory
+spec:
+    metadata:
+        Body: ""
+        Header: map[Accept:[application/json] Content-Type:[application/json] User-Agent:[nutanix]]
+        Proto: HTTP/1.1
+        ProtoMajor: "1"
+        ProtoMinor: "1"
+        URL: https://10.45.30.138:9440/karbon/v1-alpha.1/k8s/cluster-registrations/e33fd0fd-5673-45fa-825d-7ef869a91577
+        name: http-client
+        operation: GET
+        type: HTTP_CLIENT
+    req:
+        method: GET
+        proto_major: 1
+        proto_minor: 1
+        url: https://10.45.30.138:9440/karbon/v1-alpha.1/k8s/cluster-registrations/e33fd0fd-5673-45fa-825d-7ef869a91577
+        header:
+            Accept: application/json
+            Content-Type: application/json
+            User-Agent: nutanix
+        body: ""
+        body_type: utf-8
+    resp:
+        status_code: 404
+        header:
+            Content-Security-Policy: 'default-src ''self'' *.nutanix.com nutanix.com; script-src ''self'' ''unsafe-inline'' ''unsafe-eval''; style-src ''self'' ''unsafe-inline'' ''unsafe-eval''; connect-src ''self'' wss: https://downloads.frame.nutanix.com https://downloads.frame.nutanix.us; img-src ''self'' blob: data:; frame-src ''self'' https://*.nutanix.com blob: data:'
+            Content-Type: application/json
+            Date: Fri, 20 Jan 2023 02:53:02 GMT
+            Server: envoy
+            Set-Cookie: Expires=Fri, 20-Jan-2023 03:08:00 GMT;Path=/;Secure;HttpOnly;SameSite=Lax
+            Strict-Transport-Security: max-age=8640000:includeSubdomains
+            Vary: Accept-Encoding
+            X-Content-Type-Options: nosniff
+            X-Dns-Prefetch-Control: "off"
+            X-Envoy-Upstream-Service-Time: "2259"
+            X-Frame-Options: SAMEORIGIN
+            X-Ntnx-Env: pc
+            X-Ntnx-Product: pc.2021.9.0.4
+            X-Permitted-Cross-Domain-Policies: master-only
+            X-Powered-By: Express
+            X-Webkit-Csp: 'default-src ''self'' *.nutanix.com nutanix.com; script-src ''self'' ''unsafe-inline'' ''unsafe-eval'';  style-src ''self'' ''unsafe-inline'' ''unsafe-eval''; connect-src ''self'' wss: https://downloads.frame.nutanix.com https://downloads.frame.nutanix.us; img-src ''self'' blob: data:; frame-src ''self'' https://*.nutanix.com blob: data:'
+            X-Xss-Protection: 1; mode=block
+        body: |
+            {"message_info":{"Cluster Get":"Failed to determine the cluster status"}}
+        body_type: utf-8
+        status_message: ""
+        proto_major: 0
+        proto_minor: 0
+    objects:
+        - type: error
+          data: H4sIAAAAAAAA/wEAAP//AAAAAAAAAAA=
+---
+version: api.keploy.io/v1beta2
+kind: Http
+name: TestKarbonCreateClusterRegistrationWithNoCategory
+spec:
+    metadata:
+        Body: |
+            {"metadata":{"api_version":"v1.1.0"},"name":"cluster2","uuid":"e33fd0fd-5673-45fa-825d-7ef869a91577"}
+        Header: map[Accept:[application/json] Content-Type:[application/json] User-Agent:[nutanix]]
+        Proto: HTTP/1.1
+        ProtoMajor: "1"
+        ProtoMinor: "1"
+        URL: https://10.45.30.138:9440/karbon/v1-alpha.1/k8s/cluster-registrations/
+        name: http-client
+        operation: POST
+        type: HTTP_CLIENT
+    req:
+        method: POST
+        proto_major: 1
+        proto_minor: 1
+        url: https://10.45.30.138:9440/karbon/v1-alpha.1/k8s/cluster-registrations/
+        header:
+            Accept: application/json
+            Content-Type: application/json
+            User-Agent: nutanix
+        body: |
+            {"metadata":{"api_version":"v1.1.0"},"name":"cluster2","uuid":"e33fd0fd-5673-45fa-825d-7ef869a91577"}
+        body_type: utf-8
+    resp:
+        status_code: 500
+        header:
+            Content-Security-Policy: 'default-src ''self'' *.nutanix.com nutanix.com; script-src ''self'' ''unsafe-inline'' ''unsafe-eval''; style-src ''self'' ''unsafe-inline'' ''unsafe-eval''; connect-src ''self'' wss: https://downloads.frame.nutanix.com https://downloads.frame.nutanix.us; img-src ''self'' blob: data:; frame-src ''self'' https://*.nutanix.com blob: data:'
+            Content-Type: application/json
+            Date: Fri, 20 Jan 2023 02:53:03 GMT
+            Server: envoy
+            Set-Cookie: Expires=Fri, 20-Jan-2023 03:08:03 GMT;Path=/;Secure;HttpOnly;SameSite=Lax
+            Strict-Transport-Security: max-age=8640000:includeSubdomains
+            Vary: Accept-Encoding
+            X-Content-Type-Options: nosniff
+            X-Dns-Prefetch-Control: "off"
+            X-Envoy-Upstream-Service-Time: "280"
+            X-Frame-Options: SAMEORIGIN
+            X-Ntnx-Env: pc
+            X-Ntnx-Product: pc.2021.9.0.4
+            X-Permitted-Cross-Domain-Policies: master-only
+            X-Powered-By: Express
+            X-Webkit-Csp: 'default-src ''self'' *.nutanix.com nutanix.com; script-src ''self'' ''unsafe-inline'' ''unsafe-eval'';  style-src ''self'' ''unsafe-inline'' ''unsafe-eval''; connect-src ''self'' wss: https://downloads.frame.nutanix.com https://downloads.frame.nutanix.us; img-src ''self'' blob: data:; frame-src ''self'' https://*.nutanix.com blob: data:'
+            X-Xss-Protection: 1; mode=block
+        body: |
+            {"message_info":{"Cluster Create":"Failed to validate the category mapping. No category mappings provided."}}
+        body_type: utf-8
+        status_message: ""
+        proto_major: 0
+        proto_minor: 0
+    objects:
+        - type: error
+          data: H4sIAAAAAAAA/wEAAP//AAAAAAAAAAA=

--- a/karbon/mocks/TestKarbonCreateClusterRegistrationWithNoCategory.yaml
+++ b/karbon/mocks/TestKarbonCreateClusterRegistrationWithNoCategory.yaml
@@ -8,7 +8,7 @@ spec:
         Proto: HTTP/1.1
         ProtoMajor: "1"
         ProtoMinor: "1"
-        URL: https://10.45.30.138:9440/karbon/v1-alpha.1/k8s/cluster-registrations/e33fd0fd-5673-45fa-825d-7ef869a91577
+        URL: https://prism-test.nutanix.com:9440/karbon/v1-alpha.1/k8s/cluster-registrations/e33fd0fd-5673-45fa-825d-7ef869a91577
         name: http-client
         operation: GET
         type: HTTP_CLIENT
@@ -16,7 +16,7 @@ spec:
         method: GET
         proto_major: 1
         proto_minor: 1
-        url: https://10.45.30.138:9440/karbon/v1-alpha.1/k8s/cluster-registrations/e33fd0fd-5673-45fa-825d-7ef869a91577
+        url: https://prism-test.nutanix.com:9440/karbon/v1-alpha.1/k8s/cluster-registrations/e33fd0fd-5673-45fa-825d-7ef869a91577
         header:
             Accept: application/json
             Content-Type: application/json
@@ -64,7 +64,7 @@ spec:
         Proto: HTTP/1.1
         ProtoMajor: "1"
         ProtoMinor: "1"
-        URL: https://10.45.30.138:9440/karbon/v1-alpha.1/k8s/cluster-registrations/
+        URL: https://prism-test.nutanix.com:9440/karbon/v1-alpha.1/k8s/cluster-registrations/
         name: http-client
         operation: POST
         type: HTTP_CLIENT
@@ -72,7 +72,7 @@ spec:
         method: POST
         proto_major: 1
         proto_minor: 1
-        url: https://10.45.30.138:9440/karbon/v1-alpha.1/k8s/cluster-registrations/
+        url: https://prism-test.nutanix.com:9440/karbon/v1-alpha.1/k8s/cluster-registrations/
         header:
             Accept: application/json
             Content-Type: application/json

--- a/karbon/mocks/TestKarbonCreateClusterRegistrationWithNoUUID.yaml
+++ b/karbon/mocks/TestKarbonCreateClusterRegistrationWithNoUUID.yaml
@@ -9,7 +9,7 @@ spec:
         Proto: HTTP/1.1
         ProtoMajor: "1"
         ProtoMinor: "1"
-        URL: https://10.45.30.138:9440/karbon/v1-alpha.1/k8s/cluster-registrations/
+        URL: https://prism-test.nutanix.com:9440/karbon/v1-alpha.1/k8s/cluster-registrations/
         name: http-client
         operation: POST
         type: HTTP_CLIENT
@@ -17,7 +17,7 @@ spec:
         method: POST
         proto_major: 1
         proto_minor: 1
-        url: https://10.45.30.138:9440/karbon/v1-alpha.1/k8s/cluster-registrations/
+        url: https://prism-test.nutanix.com:9440/karbon/v1-alpha.1/k8s/cluster-registrations/
         header:
             Accept: application/json
             Content-Type: application/json

--- a/karbon/mocks/TestKarbonCreateClusterRegistrationWithNoUUID.yaml
+++ b/karbon/mocks/TestKarbonCreateClusterRegistrationWithNoUUID.yaml
@@ -1,0 +1,55 @@
+version: api.keploy.io/v1beta2
+kind: Http
+name: TestKarbonCreateClusterRegistrationWithNoUUID
+spec:
+    metadata:
+        Body: |
+            {"categories_mapping":{"KubernetesClusterName":"cluster3","kubernetes-io-cluster-cluster3":"owned"},"metadata":{"api_version":"v1.1.0"},"name":"cluster3"}
+        Header: map[Accept:[application/json] Content-Type:[application/json] User-Agent:[nutanix]]
+        Proto: HTTP/1.1
+        ProtoMajor: "1"
+        ProtoMinor: "1"
+        URL: https://10.45.30.138:9440/karbon/v1-alpha.1/k8s/cluster-registrations/
+        name: http-client
+        operation: POST
+        type: HTTP_CLIENT
+    req:
+        method: POST
+        proto_major: 1
+        proto_minor: 1
+        url: https://10.45.30.138:9440/karbon/v1-alpha.1/k8s/cluster-registrations/
+        header:
+            Accept: application/json
+            Content-Type: application/json
+            User-Agent: nutanix
+        body: |
+            {"categories_mapping":{"KubernetesClusterName":"cluster3","kubernetes-io-cluster-cluster3":"owned"},"metadata":{"api_version":"v1.1.0"},"name":"cluster3"}
+        body_type: utf-8
+    resp:
+        status_code: 422
+        header:
+            Content-Security-Policy: 'default-src ''self'' *.nutanix.com nutanix.com; script-src ''self'' ''unsafe-inline'' ''unsafe-eval''; style-src ''self'' ''unsafe-inline'' ''unsafe-eval''; connect-src ''self'' wss: https://downloads.frame.nutanix.com https://downloads.frame.nutanix.us; img-src ''self'' blob: data:; frame-src ''self'' https://*.nutanix.com blob: data:'
+            Content-Type: application/json
+            Date: Fri, 20 Jan 2023 02:56:20 GMT
+            Server: envoy
+            Set-Cookie: Expires=Fri, 20-Jan-2023 03:11:21 GMT;Path=/;Secure;HttpOnly;SameSite=Lax
+            Strict-Transport-Security: max-age=8640000:includeSubdomains
+            Vary: Accept-Encoding
+            X-Content-Type-Options: nosniff
+            X-Dns-Prefetch-Control: "off"
+            X-Envoy-Upstream-Service-Time: "210"
+            X-Frame-Options: SAMEORIGIN
+            X-Ntnx-Env: pc
+            X-Ntnx-Product: pc.2021.9.0.4
+            X-Permitted-Cross-Domain-Policies: master-only
+            X-Powered-By: Express
+            X-Webkit-Csp: 'default-src ''self'' *.nutanix.com nutanix.com; script-src ''self'' ''unsafe-inline'' ''unsafe-eval'';  style-src ''self'' ''unsafe-inline'' ''unsafe-eval''; connect-src ''self'' wss: https://downloads.frame.nutanix.com https://downloads.frame.nutanix.us; img-src ''self'' blob: data:; frame-src ''self'' https://*.nutanix.com blob: data:'
+            X-Xss-Protection: 1; mode=block
+        body: '{"code":602,"message":"uuid in body is required"}'
+        body_type: utf-8
+        status_message: ""
+        proto_major: 0
+        proto_minor: 0
+    objects:
+        - type: error
+          data: H4sIAAAAAAAA/wEAAP//AAAAAAAAAAA=

--- a/karbon/mocks/TestKarbonGetK8sRegistrationList.yaml
+++ b/karbon/mocks/TestKarbonGetK8sRegistrationList.yaml
@@ -8,7 +8,7 @@ spec:
         Proto: HTTP/1.1
         ProtoMajor: "1"
         ProtoMinor: "1"
-        URL: https://10.45.30.138:9440/karbon/v1-alpha.1/k8s/cluster-registrations/
+        URL: https://prism-test.nutanix.com:9440/karbon/v1-alpha.1/k8s/cluster-registrations/
         name: http-client
         operation: GET
         type: HTTP_CLIENT
@@ -16,7 +16,7 @@ spec:
         method: GET
         proto_major: 1
         proto_minor: 1
-        url: https://10.45.30.138:9440/karbon/v1-alpha.1/k8s/cluster-registrations/
+        url: https://prism-test.nutanix.com:9440/karbon/v1-alpha.1/k8s/cluster-registrations/
         header:
             Accept: application/json
             Content-Type: application/json


### PR DESCRIPTION
Update to add the Unit test cases below
1. Empty UUID
2. Empty Category Mapping.