### PR TITLE
Change the functional option processing order for v3

### DIFF
--- a/v3/v3.go
+++ b/v3/v3.go
@@ -75,22 +75,22 @@ func WithLogger(logger *logr.Logger) ClientOption {
 
 // NewV3Client return a internal to operate V3 resources
 func NewV3Client(credentials prismgoclient.Credentials, opts ...ClientOption) (*Client, error) {
-	v3Client := &Client{}
-	for _, opt := range opts {
-		if err := opt(v3Client); err != nil {
-			return nil, err
-		}
-	}
-
 	if credentials.Username == "" || credentials.Password == "" || credentials.Endpoint == "" {
 		return nil, fmt.Errorf("username, password and endpoint are required")
 	}
 
+	v3Client := &Client{}
 	v3Client.clientOpts = append(v3Client.clientOpts,
 		internal.WithCredentials(&credentials),
 		internal.WithUserAgent(userAgent),
 		internal.WithAbsolutePath(absolutePath),
 	)
+
+	for _, opt := range opts {
+		if err := opt(v3Client); err != nil {
+			return nil, err
+		}
+	}
 
 	httpClient, err := internal.NewClient(v3Client.clientOpts...)
 	if err != nil {

--- a/v3/v3_test.go
+++ b/v3/v3_test.go
@@ -1,12 +1,15 @@
 package v3
 
 import (
+	"net/http"
 	"testing"
 
+	"github.com/keploy/go-sdk/integrations/khttpclient"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/nutanix-cloud-native/prism-go-client"
+	"github.com/nutanix-cloud-native/prism-go-client/internal/testhelpers"
 )
 
 func TestNewV3Client(t *testing.T) {
@@ -97,6 +100,17 @@ hag8IyrhFHvBN91i0ZJsumB9iOQct+R2UTjEqUdOqCsukNK1OFHrwZyKarXMsh3o
 wFZUTKiL8IkyhtyTMr5NGvo1dbU=
 -----END CERTIFICATE-----`
 	v3Client, err := NewV3Client(cred, WithPEMEncodedCertBundle([]byte(certBundle)))
+	require.NoError(t, err)
+	assert.NotNil(t, v3Client)
+}
+
+func TestNewV3ClientWithInsecureAndCustomTransport(t *testing.T) {
+	creds := testhelpers.CredentialsFromEnvironment(t)
+	// Changing insecure to true as that leads to modifying the transport underneath
+	creds.Insecure = true
+
+	interceptor := khttpclient.NewInterceptor(http.DefaultTransport)
+	v3Client, err := NewV3Client(creds, WithRoundTripper(interceptor))
 	require.NoError(t, err)
 	assert.NotNil(t, v3Client)
 }


### PR DESCRIPTION
Functional options should be processed after credentials are validated.
This ensures there are no regressions caused due to credentials processing
twiddling the transport object.