### PR TITLE
Enhancements to support recovery plan jobs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added support for creating, deleting, listing, and getting the status of recovery plan jobs.
+
 ### Changed
 - Change the MetaService interface methods to take context.Context as a parameter
 - Local environment provider now fetches port from `NUTANIX_PORT` environment variable

--- a/v3/v3_structs.go
+++ b/v3/v3_structs.go
@@ -1625,10 +1625,9 @@ type Metadata struct {
 	// Applied on Prism Central only. Indicate whether force to translate the spec of the fanout request to fit the target cluster API schema.
 	ShouldForceTranslate *bool `json:"should_force_translate,omitempty" mapstructure:"should_force_translate,omitempty"`
 
-	// TODO: add if necessary
-	// CategoriesMapping    map[string][]string `json:"categories_mapping,omitempty" mapstructure:"categories_mapping,omitempty"`
-	// EntityVersion        *string             `json:"entity_version,omitempty" mapstructure:"entity_version,omitempty"`
-	// UseCategoriesMapping *bool               `json:"use_categories_mapping,omitempty" mapstructure:"use_categories_mapping,omitempty"`
+	CategoriesMapping    map[string][]string `json:"categories_mapping,omitempty" mapstructure:"categories_mapping,omitempty"`
+	EntityVersion        *string             `json:"entity_version,omitempty" mapstructure:"entity_version,omitempty"`
+	UseCategoriesMapping *bool               `json:"use_categories_mapping,omitempty" mapstructure:"use_categories_mapping,omitempty"`
 }
 
 // NetworkSecurityRuleIntentInput An intentful representation of a network_security_rule
@@ -2571,4 +2570,134 @@ type AddressGroupListEntry struct {
 type AddressGroupListResponse struct {
 	Metadata *ListMetadataOutput      `json:"metadata,omitempty"`
 	Entities []*AddressGroupListEntry `json:"entities,omitempty"`
+}
+
+type RecoveryPlanJobIntentInput struct {
+	APIVersion *string          `json:"api_version,omitempty"`
+	Metadata   *Metadata        `json:"metadata"`
+	Spec       *RecoveryPlanJob `json:"spec"`
+}
+
+type RecoveryPlanJob struct {
+	Name      *string                   `json:"name"`
+	Resources *RecoveryPlanJobResources `json:"resources"`
+}
+
+type RecoveryPlanJobResources struct {
+	ExecutionParameters   *RecoveryPlanJobResourcesExecutionParameters `json:"execution_parameters"`
+	RecoveryPlanReference *Reference                                   `json:"recovery_plan_reference"`
+}
+
+type RecoveryPlanJobResourcesExecutionParameters struct {
+	ActionType                        *string                 `json:"action_type"`
+	FailedAvailabilityZoneList        []*AvailabilityZoneList `json:"failed_availability_zone_list"`
+	RecoveryAvailabilityZoneList      []*AvailabilityZoneList `json:"recovery_availability_zone_list"`
+	RecoveryReferenceTime             *time.Time              `json:"recovery_reference_time,omitempty"`
+	ShouldContinueOnValidationFailure *bool                   `json:"should_continue_on_validation_failure,omitempty"`
+}
+
+type RecoveryPlanJobIntentResponse struct {
+	APIVersion *string                   `json:"api_version"`
+	Metadata   *Metadata                 `json:"metadata"`
+	Spec       *RecoveryPlanJob          `json:"spec,omitempty"`
+	Status     *RecoveryPlanJobDefStatus `json:"status,omitempty"`
+}
+
+type RecoveryPlanJobDefStatus struct {
+	CleanupStatus                  *RecoveryPlanJobExecutionPhasesStatus `json:"cleanup_status,omitempty"`
+	EndTime                        *time.Time                            `json:"end_time,omitempty"`
+	ExecutionStatus                *RecoveryPlanJobExecutionPhasesStatus `json:"execution_status,omitempty"`
+	Name                           *string                               `json:"name"`
+	ParentRecoveryPlanJobReference *Reference                            `json:"parent_recovery_plan_job_reference,omitempty"`
+	RecoveryPlanSpecification      *RecoveryPlanSpec                     `json:"recovery_plan_specification,omitempty"`
+	Resources                      *RecoveryPlanJobResources             `json:"resources"`
+	RootRecoveryPlanJobReference   *Reference                            `json:"root_recovery_plan_job_reference,omitempty"`
+	StartTime                      *time.Time                            `json:"start_time,omitempty"`
+	ValidationInformation          *RecoveryPlanJobValidationInformation `json:"validation_information,omitempty"`
+	WitnessAddress                 string                                `json:"witness_address,omitempty"`
+}
+
+type RecoveryPlanJobExecutionPhasesStatus struct {
+	OperationStatus      *RecoveryPlanJobStepStatus `json:"operation_status,omitempty"`
+	PercentageComplete   *int32                     `json:"percentage_complete"`
+	PostprocessingStatus *RecoveryPlanJobStepStatus `json:"postprocessing_status,omitempty"`
+	PreprocessingStatus  *RecoveryPlanJobStepStatus `json:"preprocessing_status,omitempty"`
+	Status               *string                    `json:"status"`
+}
+
+type RecoveryPlanJobStepStatus struct {
+	PercentageComplete *int32  `json:"percentage_complete"`
+	Status             *string `json:"status"`
+}
+
+type RecoveryPlanJobValidationInformation struct {
+	ErrorsList   []*RecoveryPlanValidationMessage `json:"errors_list"`
+	WarningsList []*RecoveryPlanValidationMessage `json:"warnings_list"`
+}
+
+type RecoveryPlanValidationMessage struct {
+	AffectedAnyReferenceList      []*Reference                 `json:"affected_any_reference_list"`
+	CauseAndResolutionMessageList []*CauseAndResolutionMessage `json:"cause_and_resolution_message_list"`
+	ImpactMessageList             []string                     `json:"impact_message_list"`
+	Message                       *string                      `json:"message"`
+	ValidationType                *string                      `json:"validation_type"`
+}
+
+type CauseAndResolutionMessage struct {
+	Cause          *string  `json:"cause"`
+	ResolutionList []string `json:"resolution_list"`
+}
+
+type RecoveryPlanJobResponse struct {
+	TaskUUID string `json:"task_uuid,omitempty"`
+}
+
+type RecoveryPlanJobExecutionStatus struct {
+	OperationStatus      *RecoveryPlanJobPhaseExecutionStatus `json:"operation_status,omitempty"`
+	PostprocessingStatus *RecoveryPlanJobPhaseExecutionStatus `json:"postprocessing_status,omitempty"`
+	PreprocessingStatus  *RecoveryPlanJobPhaseExecutionStatus `json:"preprocessing_status,omitempty"`
+}
+
+type RecoveryPlanJobPhaseExecutionStatus struct {
+	PercentageComplete      int32                                 `json:"percentage_complete,omitempty"`
+	Status                  string                                `json:"status,omitempty"`
+	StepExecutionStatusList []*RecoveryPlanJobStepExecutionStatus `json:"step_execution_status_list"`
+}
+
+type RecoveryPlanJobStepExecutionStatus struct {
+	AnyEntityReferenceList  []*Reference                  `json:"any_entity_reference_list"`
+	EndTime                 *time.Time                    `json:"end_time,omitempty"`
+	ErrorCode               string                        `json:"error_code,omitempty"`
+	ErrorDetail             string                        `json:"error_detail,omitempty"`
+	Message                 string                        `json:"message,omitempty"`
+	OperationType           *string                       `json:"operation_type"`
+	ParentStepUUID          string                        `json:"parent_step_uuid,omitempty"`
+	PercentageComplete      int32                         `json:"percentage_complete,omitempty"`
+	RecoveredEntityInfoList []*RecoveredEntityInformation `json:"recovered_entity_info_list"`
+	StartTime               *time.Time                    `json:"start_time,omitempty"`
+	Status                  *string                       `json:"status"`
+	StepSequenceNumber      int64                         `json:"step_sequence_number,omitempty"`
+	StepUUID                *string                       `json:"step_uuid"`
+}
+
+type RecoveredEntityInformation struct {
+	ErrorDetail           string           `json:"error_detail,omitempty"`
+	RecoveredEntityInfo   *RecoveredEntity `json:"recovered_entity_info,omitempty"`
+	SourceEntityReference *Reference       `json:"source_entity_reference,omitempty"`
+}
+
+type RecoveredEntity struct {
+	EntityName string `json:"entity_name,omitempty"`
+	EntityUUID string `json:"entity_uuid,omitempty"`
+}
+
+type RecoveryPlanJobListResponse struct {
+	APIVersion *string                          `json:"api_version"`
+	Entities   []*RecoveryPlanJobIntentResponse `json:"entities"`
+	Metadata   *ListMetadataOutput              `json:"metadata"`
+}
+
+type RecoveryPlanJobActionRequest struct {
+	RerunRecoveryPlanJobUUID               string `json:"rerun_recovery_plan_job_uuid,omitempty"`
+	ShouldContinueRerunOnValidationFailure *bool  `json:"should_continue_rerun_on_validation_failure,omitempty"`
 }


### PR DESCRIPTION
RecoveryPlanJobs are the way to run recovery plans during failover and failback. This patch adds support for all the API endpoints related to recovery plan jobs.