### PR TITLE
fix: remove unexported method v3 Service interface

### DIFF
--- a/v3/v3_service.go
+++ b/v3/v3_service.go
@@ -111,7 +111,6 @@ type Service interface {
 	UpdateRecoveryPlan(ctx context.Context, uuid string, body *RecoveryPlanInput) (*RecoveryPlanResponse, error)
 	DeleteRecoveryPlan(ctx context.Context, uuid string) (*DeleteResponse, error)
 	GetServiceGroup(ctx context.Context, uuid string) (*ServiceGroupResponse, error)
-	listServiceGroups(ctx context.Context, getEntitiesRequest *DSMetadata) (*ServiceGroupListResponse, error)
 	ListAllServiceGroups(ctx context.Context, filter string) (*ServiceGroupListResponse, error)
 	CreateServiceGroup(ctx context.Context, request *ServiceGroupInput) (*Reference, error)
 	UpdateServiceGroup(ctx context.Context, uuid string, body *ServiceGroupInput) error


### PR DESCRIPTION
Having an unexported method in an interface makes it not possible to implement from a different package

e.g. Trying to create a mock implementation leads to this error: 
```
Type cannot implement 'Service' as it has a non-exported method and is defined in a different package
```