### PR TITLE
Session Auth Token Refresh and V3 Client Cache

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -18,10 +18,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
-        go-version: '^1.18'
-
-    - name: Install dependencies
-      run: make vendor
+        go-version: '^1.21'
 
     - name: Check build
       run: make build
@@ -45,4 +42,3 @@ jobs:
 
     - name: Codecov
       uses: codecov/codecov-action@v3.1.4
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,28 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Added support for v4 client creation.
-
-### Added
 - Added support for getting information about an AZ given a uuid.
-
-### Added
 - Added support for getting a projection of attributes of entities using the 'groups' API endpoint.
-
-### Added
 - Added support for creating, deleting, listing, and getting the status of recovery plan jobs.
+- Add optional function options for the NewKarbonAPIClient constructor
+- Add ClusterRegistration interface in karbon package
+- Add ClusterRegistration SetInfo and Cluster Addon SetInfo APIs
+- Added support for specifying volume groups by category in a recovery plan create request.
+- Added support for specifying primary and recovery clusters in a recovery plan.
+- Added WithUserAgent client option for v3 client constructor.
 
 ### Changed
 - Change the MetaService interface methods to take context.Context as a parameter
 - Local environment provider now fetches port from `NUTANIX_PORT` environment variable
-
-### Added
-- Add optional function options for the NewKarbonAPIClient constructor
-- Add ClusterRegistration interface in karbon package
-- Add ClusterRegistration SetInfo and Cluster Addon SetInfo APIs
-
-### Added
-- Added support for specifying volume groups by category in a recovery plan create request.
-- Added support for specifying primary and recovery clusters in a recovery plan.
+- Add logic to internal.Client for auto retry once after refreshing auth cookie on a 401 response in case of session auth.
 
 ## [0.3.4] - 2022-11-24
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for specifying volume groups by category in a recovery plan create request.
 - Added support for specifying primary and recovery clusters in a recovery plan.
 - Added WithUserAgent client option for v3 client constructor.
+- Added Cache for v3 Clients in v3 package.
 
 ### Changed
 - Change the MetaService interface methods to take context.Context as a parameter

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ lint: lint-go lint-yaml lint-kubebuilder ## Run all available linters
 
 lint-go: ## Use golintci-lint on your project
 	$(eval OUTPUT_OPTIONS = $(shell [ "${EXPORT_RESULT}" == "true" ] && echo "--out-format checkstyle ./... | tee /dev/tty > checkstyle-report.xml" || echo "" ))
-	docker run --rm -v $(shell pwd):/app -w /app golangci/golangci-lint:latest-alpine golangci-lint run --enable gofmt --fix --enable gofumpt --deadline=300s $(OUTPUT_OPTIONS)
+	docker run --rm -v $(shell pwd):/app -w /app golangci/golangci-lint:latest-alpine golangci-lint run --enable gofmt --fix --enable gofumpt $(OUTPUT_OPTIONS)
 
 lint-yaml: ## Use yamllint on the yaml file of your projects
 ifeq ($(EXPORT_RESULT), true)

--- a/Makefile
+++ b/Makefile
@@ -11,16 +11,16 @@ WHITE  := $(shell tput -Txterm setaf 7)
 CYAN   := $(shell tput -Txterm setaf 6)
 RESET  := $(shell tput -Txterm sgr0)
 
-.PHONY: all test build vendor
+.PHONY: all test build
 
 all: help
 
 ## Build:
-build: vendor ## Build your project and put the output binary in bin/
+build: ## Build your project and put the output binary in bin/
 	mkdir -p bin
-	GO111MODULE=on $(GOCMD) build -mod vendor -o bin/$(BINARY_NAME) .
+	$(GOCMD) build -o bin/$(BINARY_NAME) .
 
-# go-get-tool will 'go get' any package $2 and install it to $1.
+# go-get-tool will 'go install' any package $2 and install it to $1.
 # originally copied from kubebuilder
 define go-get-tool
 @[ -f $(1) ] || { \
@@ -72,13 +72,10 @@ clean: ## Remove build related file
 	rm -fr ./bin vendor hack/tools/bin
 	rm -f ./junit-report.xml checkstyle-report.xml ./coverage.xml ./profile.cov yamllint-checkstyle.xml
 
-vendor: ## Copy of all packages needed to support builds and tests in the vendor directory
-	$(GOCMD) mod vendor
-
 ## Test:
 test: run-keploy ## Run the tests of the project
 ifeq ($(EXPORT_RESULT), true)
-	GO111MODULE=off go get -u github.com/jstemmer/go-junit-report
+	go install github.com/jstemmer/go-junit-report
 	$(eval OUTPUT_OPTIONS = | tee /dev/tty | go-junit-report -set-exit-code > junit-report.xml)
 endif
 	$(GOTEST) -v -race ./... $(OUTPUT_OPTIONS)
@@ -88,12 +85,11 @@ coverage: run-keploy ## Run the tests of the project and export the coverage
 	$(GOTEST) -cover -covermode=count -coverprofile=profile.cov ./...
 	$(GOCMD) tool cover -func profile.cov
 ifeq ($(EXPORT_RESULT), true)
-	GO111MODULE=off go get -u github.com/AlekSi/gocov-xml
-	GO111MODULE=off go get -u github.com/axw/gocov/gocov
+	go install github.com/AlekSi/gocov-xml
+	go install github.com/axw/gocov/gocov
 	gocov convert profile.cov | gocov-xml > coverage.xml
 endif
 	@$(MAKE) stop-keploy
-
 
 ## Lint:
 lint: lint-go lint-yaml lint-kubebuilder ## Run all available linters
@@ -104,10 +100,10 @@ lint-go: ## Use golintci-lint on your project
 
 lint-yaml: ## Use yamllint on the yaml file of your projects
 ifeq ($(EXPORT_RESULT), true)
-	GO111MODULE=off go get -u github.com/thomaspoignant/yamllint-checkstyle
+	go install github.com/thomaspoignant/yamllint-checkstyle
 	$(eval OUTPUT_OPTIONS = | tee /dev/tty | yamllint-checkstyle > yamllint-checkstyle.xml)
 endif
-	docker run --rm -it -v $(shell pwd):/data cytopia/yamllint -d relaxed -f parsable $(shell git ls-files '*.yml' '*.yaml') $(OUTPUT_OPTIONS)
+	docker run --rm -it -v $(shell pwd):/data cytopia/yamllint -c yamllint-config.yaml -f parsable $(shell git ls-files '*.yml' '*.yaml') $(OUTPUT_OPTIONS)
 
 .PHONY: lint-kubebuilder
 lint-kubebuilder: $(CONTROLLER_GEN) ## Lint Kubebuilder annotations by generating objects and checking if it is successful

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ CONTROLLER_GEN := $(TOOLS_BIN_DIR)/$(CONTROLLER_GEN_BIN)
 CRD_OPTIONS ?= "crd:crdVersions=v1"
 
 $(CONTROLLER_GEN): $(TOOLS_BIN_DIR)
-	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.1)
+	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.14.0)
 
 KEPLOY_VER := v0.7.12
 KEPLOY_BIN := server-$(KEPLOY_VER)

--- a/environment/types/types.go
+++ b/environment/types/types.go
@@ -18,11 +18,11 @@ var ErrNotFound = fmt.Errorf("environment key not found")
 // the underlying infrastructure.
 type ApiCredentials struct {
 	// Username for basic authentication
-	Username string `json:"username"`
+	Username string `json:"username,omitempty"`
 	// Password for basic authentication
-	Password string `json:"password"`
+	Password string `json:"password,omitempty"`
 	// KeyPair is JSON-encoded key pair for TLS client authentication
-	KeyPair string `json:"keyPair"`
+	KeyPair string `json:"keyPair,omitempty"`
 }
 
 // ManagementEndpoint specifies API endpoint used for interacting with underlying
@@ -31,14 +31,14 @@ type ManagementEndpoint struct {
 	// ApiCredentials embedded into endpoint
 	ApiCredentials
 	// Address is URL of management endpoint
-	Address *url.URL `json:"address"`
+	Address *url.URL `json:"address,omitempty"`
 	// Whether to authenticate TLS endpoint in case of HTTPS as transport.
 	// HTTPS is used for encryption independent of this setting. An
 	// unauthenticated TLS endpoint is prone to man-in-the-middle attacks.
-	Insecure bool `json:"insecure"`
+	Insecure bool `json:"insecure,omitempty"`
 	// AdditionalTrustBundle is a PEM-encoded certificate bundle to be used
 	// in addition to system trust store
-	AdditionalTrustBundle string `json:"additionalTrustBundle"`
+	AdditionalTrustBundle string `json:"additionalTrustBundle,omitempty"`
 }
 
 // Topology is a map of topological domains to topological segments.

--- a/environment/types/types.go
+++ b/environment/types/types.go
@@ -18,11 +18,11 @@ var ErrNotFound = fmt.Errorf("environment key not found")
 // the underlying infrastructure.
 type ApiCredentials struct {
 	// Username for basic authentication
-	Username string
+	Username string `json:"username"`
 	// Password for basic authentication
-	Password string
+	Password string `json:"password"`
 	// KeyPair is JSON-encoded key pair for TLS client authentication
-	KeyPair string
+	KeyPair string `json:"keyPair"`
 }
 
 // ManagementEndpoint specifies API endpoint used for interacting with underlying
@@ -31,14 +31,14 @@ type ManagementEndpoint struct {
 	// ApiCredentials embedded into endpoint
 	ApiCredentials
 	// Address is URL of management endpoint
-	Address *url.URL
+	Address *url.URL `json:"address"`
 	// Whether to authenticate TLS endpoint in case of HTTPS as transport.
 	// HTTPS is used for encryption independent of this setting. An
 	// unauthenticated TLS endpoint is prone to man-in-the-middle attacks.
-	Insecure bool
+	Insecure bool `json:"insecure"`
 	// AdditionalTrustBundle is a PEM-encoded certificate bundle to be used
 	// in addition to system trust store
-	AdditionalTrustBundle string
+	AdditionalTrustBundle string `json:"additionalTrustBundle"`
 }
 
 // Topology is a map of topological domains to topological segments.

--- a/go.mod
+++ b/go.mod
@@ -26,10 +26,14 @@ require (
 )
 
 require (
+	bitbucket.org/creachadair/shell v0.0.6 // indirect
 	github.com/99designs/gqlgen v0.15.1 // indirect
+	github.com/AlekSi/gocov-xml v1.1.0 // indirect
 	github.com/PaesslerAG/gval v1.0.0 // indirect
 	github.com/agnivade/levenshtein v1.1.1 // indirect
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de // indirect
+	github.com/axw/gocov v1.1.0 // indirect
+	github.com/bitfield/script v0.18.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.1 // indirect
 	github.com/creasty/defaults v1.5.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
@@ -55,6 +59,7 @@ require (
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/jstemmer/go-junit-report v1.0.0 // indirect
 	github.com/k0kubun/pp/v3 v3.1.0 // indirect
 	github.com/klauspost/compress v1.15.1 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect
@@ -70,6 +75,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
+	github.com/thomaspoignant/yamllint-checkstyle v1.0.2 // indirect
 	github.com/tidwall/gjson v1.14.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,10 @@
+bitbucket.org/creachadair/shell v0.0.6 h1:reJflDbKqnlnqb4Oo2pQ1/BqmY/eCWcNGHrIUO8qIzc=
+bitbucket.org/creachadair/shell v0.0.6/go.mod h1:8Qqi/cYk7vPnsOePHroKXDJYmb5x7ENhtiFtfZq8K+M=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/99designs/gqlgen v0.15.1 h1:48bRXecwlCNTa/n2bMSp2rQsXNxwZ54QHbiULNf78ec=
 github.com/99designs/gqlgen v0.15.1/go.mod h1:nbeSjFkqphIqpZsYe1ULVz0yfH8hjpJdJIQoX/e0G2I=
+github.com/AlekSi/gocov-xml v1.1.0 h1:iElWGi7s/MuL8/d8WDtI2fOAsN3ap9x8nK5RrAhaDng=
+github.com/AlekSi/gocov-xml v1.1.0/go.mod h1:g1dRVOCHjKkMtlPfW6BokJ/qxoeZ1uPNAK7A/ii3CUo=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/PaesslerAG/gval v1.0.0 h1:GEKnRwkWDdf9dOmKcNrar9EA1bz1z9DqPIO1+iLzhd8=
 github.com/PaesslerAG/gval v1.0.0/go.mod h1:y/nm5yEyTeX6av0OfKJNp9rBNj2XrGhAf5+v24IBN1I=
@@ -17,8 +21,12 @@ github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de h1:FxWPpzIjnTlhP
 github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de/go.mod h1:DCaWoUhZrYW9p1lxo/cm8EmUOOzAPSEZNGF2DK1dJgw=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
+github.com/axw/gocov v1.1.0 h1:y5U1krExoJDlb/kNtzxyZQmNRprFOFCutWbNjcQvmVM=
+github.com/axw/gocov v1.1.0/go.mod h1:H9G4tivgdN3pYSSVrTFBr6kGDCmAkgbJhtxFzAvgcdw=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
+github.com/bitfield/script v0.18.0 h1:F4sg0y06aVb8/rLOpa2RoPXq3aob+oIQP3Xo4tT3c2I=
+github.com/bitfield/script v0.18.0/go.mod h1:YGjrl5cZB++zV0DD8/tZmekyjaMDm4UMjatdA84FGj0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
@@ -119,6 +127,8 @@ github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8Hm
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/jstemmer/go-junit-report v1.0.0 h1:8X1gzZpR+nVQLAht+L/foqOeX2l9DTZoaIPbEQHxsds=
+github.com/jstemmer/go-junit-report v1.0.0/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/k0kubun/pp/v3 v3.1.0 h1:ifxtqJkRZhw3h554/z/8zm6AAbyO4LLKDlA5eV+9O8Q=
 github.com/k0kubun/pp/v3 v3.1.0/go.mod h1:vIrP5CF0n78pKHm2Ku6GVerpZBJvscg48WepUYEk2gw=
 github.com/keploy/go-sdk v0.7.2 h1:mvvjDRciMSFTgOF/KIGz38ElJZKkM1WlniaHseaPhpo=
@@ -217,6 +227,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/thomaspoignant/yamllint-checkstyle v1.0.2 h1:mGgEeBgZhGZ5GUYv1pMEydyh1itMorUaVXmd1xld588=
+github.com/thomaspoignant/yamllint-checkstyle v1.0.2/go.mod h1:hfra2golykYl9vaU4GuCbtiQTgNJ5zGpjT9ztxC1MnQ=
 github.com/tidwall/gjson v1.14.0 h1:6aeJ0bzojgWLa82gDQHcx3S0Lr/O51I9bJ5nv6JFx5w=
 github.com/tidwall/gjson v1.14.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
@@ -343,6 +355,7 @@ golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190531172133-b3315ee88b7d/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
+golang.org/x/tools v0.0.0-20190617190820-da514acc4774/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20191108193012-7d206e10da11/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=

--- a/internal/client.go
+++ b/internal/client.go
@@ -485,6 +485,11 @@ func (c *Client) Do(ctx context.Context, req *http.Request, v interface{}) error
 	noRetries := 0
 	retryOnce := 1
 
+	// It's recommend that the clients use session-auth cookies instead of basic auth for requests to Prism Central
+	// where possible. Session tokens are alive for 15m and then replaced. The session-auth handling mechanism in
+	// the client should be resilient to session token refresh. As long the credentials are accurate and session
+	// auth mechanism is in play, the client upon receiving the first 401 should refresh the session cookie and
+	// retry the request. Only if the requests fails the second time, should the client return a 401 back to the caller.
 	if c.credentials.SessionAuth {
 		return c.do(ctx, req, v, noRetries, retryOnce)
 	}

--- a/internal/testhelpers/creds.go
+++ b/internal/testhelpers/creds.go
@@ -12,6 +12,7 @@ import (
 
 	prismgoclient "github.com/nutanix-cloud-native/prism-go-client"
 	"github.com/nutanix-cloud-native/prism-go-client/environment/providers/local"
+	"github.com/nutanix-cloud-native/prism-go-client/environment/types"
 )
 
 const (
@@ -97,6 +98,20 @@ func getDeveloperConfig(t *testing.T, filePath string) devConf {
 // Alternatively, the path to the developer config file can be set in the environment variable `PRISM_DEV_CONFIG`.
 // More information about the developer config file can be found in the DEVELOPMENT.md in repo root.
 func CredentialsFromEnvironment(t *testing.T) prismgoclient.Credentials {
+	endpoint := ManagementEndpointFromEnvironment(t)
+
+	return prismgoclient.Credentials{
+		Endpoint: endpoint.Address.Host,
+		Port:     endpoint.Address.Port(),
+		URL:      endpoint.Address.String(),
+		Username: endpoint.Username,
+		Password: endpoint.Password,
+		Insecure: endpoint.Insecure,
+	}
+}
+
+// ManagementEndpointFromEnvironment returns a ManagementEndpoint object from the developer environment
+func ManagementEndpointFromEnvironment(t *testing.T) *types.ManagementEndpoint {
 	confFile, err := prismDevConfigFilePath()
 	require.NoError(t, err)
 	conf := getDeveloperConfig(t, confFile)
@@ -109,15 +124,8 @@ func CredentialsFromEnvironment(t *testing.T) prismgoclient.Credentials {
 	t.Setenv("NUTANIX_USERNAME", conf.PrismCentral.Username)
 	t.Setenv("NUTANIX_PASSWORD", conf.PrismCentral.Password)
 	t.Setenv("NUTANIX_INSECURE", strconv.FormatBool(conf.PrismCentral.Insecure))
-	provider, err := local.NewProvider().GetManagementEndpoint(nil)
+	endpoint, err := local.NewProvider().GetManagementEndpoint(nil)
 	require.NoError(t, err)
 
-	return prismgoclient.Credentials{
-		Endpoint: conf.PrismCentral.Endpoint,
-		Port:     conf.PrismCentral.Port,
-		URL:      provider.Address.String(),
-		Username: provider.Username,
-		Password: provider.Password,
-		Insecure: provider.Insecure,
-	}
+	return endpoint
 }

--- a/v3/cache.go
+++ b/v3/cache.go
@@ -1,0 +1,194 @@
+package v3
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/nutanix-cloud-native/prism-go-client"
+	"github.com/nutanix-cloud-native/prism-go-client/environment/types"
+)
+
+type clientCacheMap map[string]*Client
+
+var (
+	// ErrorClientNotFound is returned when the client is not found in the cache
+	ErrorClientNotFound = errors.New("client not found in client cache")
+	// ErrorPrismAddressNotSet is returned when the address is not set for Nutanix Prism Central
+	ErrorPrismAddressNotSet = errors.New("address not set for Nutanix Prism Central")
+	// ErrorPrismPortNotSet is returned when the port is not set for Nutanix Prism Central
+	ErrorPrismPortNotSet = errors.New("port not set for Nutanix Prism Central")
+	// ErrorPrismUsernameNotSet is returned when the username is not set for Nutanix Prism Central
+	ErrorPrismUsernameNotSet = errors.New("username not set for Nutanix Prism Central")
+	// ErrorPrismPasswordNotSet is returned when the password is not set for Nutanix Prism Central
+	ErrorPrismPasswordNotSet = errors.New("password not set for Nutanix Prism Central")
+)
+
+// ClientCache is a cache for prism clients
+type ClientCache struct {
+	cache            clientCacheMap
+	validationHashes map[string]string
+	mtx              sync.RWMutex
+
+	useSessionAuth bool
+}
+
+// CacheOpts is a functional option for the ClientCache
+type CacheOpts func(*ClientCache)
+
+// WithSessionAuth sets the session auth for the ClientCache
+func WithSessionAuth(sessionAuth bool) CacheOpts {
+	return func(c *ClientCache) {
+		c.useSessionAuth = sessionAuth
+	}
+}
+
+// NewClientCache returns a new ClientCache
+func NewClientCache(opts ...CacheOpts) *ClientCache {
+	cache := &ClientCache{
+		cache:            make(clientCacheMap),
+		validationHashes: make(map[string]string),
+		mtx:              sync.RWMutex{},
+	}
+
+	for _, opt := range opts {
+		opt(cache)
+	}
+
+	return cache
+}
+
+// CachedClientParams define the interface that needs to be implemented by an object that will be used to create
+// a cached client.
+type CachedClientParams interface {
+	ManagementEndpoint() types.ManagementEndpoint
+	Key() string
+}
+
+// GetOrCreate returns the client for the given client name and endpoint.
+// - If the client is not found in the cache, it creates a new client, adds it to the cache, and returns it
+// - If the client is found in the cache, it validates whether the client is still valid by comparing validation hashes
+// - If the client is found in the cache and the validation hash is the same, it returns the client
+// - If the client is found in the cache and the validation hash is different, it regenerates the client, updates the cache, and returns the client
+// func (c *ClientCache) GetOrCreate(clientName string, endpoint types.ManagementEndpoint, opts ...ClientOption) (*Client, error) {
+func (c *ClientCache) GetOrCreate(cachedClientParams CachedClientParams, opts ...ClientOption) (*Client, error) {
+	currentValidationHash, err := validationHashFromEndpoint(cachedClientParams.ManagementEndpoint())
+	client, validationHash, err := c.get(cachedClientParams.Key())
+	if err != nil {
+		if !errors.Is(err, ErrorClientNotFound) {
+			return nil, err
+		}
+	}
+
+	if validationHash == currentValidationHash {
+		// validation hash is the same, return the client
+		return client, nil
+	}
+
+	// validation hash is different, regenerate the client
+	c.Delete(cachedClientParams)
+
+	credentials := prismgoclient.Credentials{
+		URL:         cachedClientParams.ManagementEndpoint().Address.Host,
+		Endpoint:    cachedClientParams.ManagementEndpoint().Address.Host,
+		Insecure:    cachedClientParams.ManagementEndpoint().Insecure,
+		Username:    cachedClientParams.ManagementEndpoint().ApiCredentials.Username,
+		Password:    cachedClientParams.ManagementEndpoint().ApiCredentials.Password,
+		SessionAuth: c.useSessionAuth,
+	}
+
+	setDefaultsForCredentials(&credentials)
+	if err := validateCredentials(credentials); err != nil {
+		return nil, err
+	}
+
+	if cachedClientParams.ManagementEndpoint().AdditionalTrustBundle != "" {
+		opts = append(opts, WithPEMEncodedCertBundle([]byte(cachedClientParams.ManagementEndpoint().AdditionalTrustBundle)))
+	}
+
+	client, err = NewV3Client(credentials, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create new nutanix prism central client: %w", err)
+	}
+
+	c.set(cachedClientParams.Key(), currentValidationHash, client)
+	return client, nil
+}
+
+func validationHashFromEndpoint(endpoint types.ManagementEndpoint) (string, error) {
+	// Note: this will only work reliably as long as types.ManagementEndpoint is predictably serializable i.e. does
+	// not contain a map. Due to randomized ordering of map keys in Go, we would constantly invalidate caches
+	// if the ManagementEndpoint has a map.
+	serializedEndpoint, err := json.Marshal(endpoint)
+	if err != nil {
+		return "", err
+	}
+
+	hasher := sha256.New()
+	hasher.Write(serializedEndpoint)
+	hashedBytes := hasher.Sum(nil)
+	currentValidationHash := hex.EncodeToString(hashedBytes)
+
+	return currentValidationHash, nil
+}
+
+func setDefaultsForCredentials(credentials *prismgoclient.Credentials) {
+	if credentials.Port == "" {
+		credentials.Port = "9440"
+	}
+
+	if credentials.URL == "" {
+		credentials.URL = fmt.Sprintf("%s:%s", credentials.Endpoint, credentials.Port)
+	}
+}
+
+func validateCredentials(credentials prismgoclient.Credentials) error {
+	if credentials.Username == "" {
+		return ErrorPrismUsernameNotSet
+	}
+
+	if credentials.Password == "" {
+		return ErrorPrismPasswordNotSet
+	}
+
+	return nil
+}
+
+// Get returns the client and the validation hash for the given client name
+func (c *ClientCache) get(clientName string) (*Client, string, error) {
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
+
+	clnt, ok := c.cache[clientName]
+	if !ok {
+		return nil, "", ErrorClientNotFound
+	}
+
+	validationHash, ok := c.validationHashes[clientName]
+	if !ok {
+		return clnt, "", nil
+	}
+
+	return clnt, validationHash, nil
+}
+
+// Set adds the client to the cache
+func (c *ClientCache) set(clientName string, validationHash string, client *Client) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	c.cache[clientName] = client
+	c.validationHashes[clientName] = validationHash
+}
+
+// Delete removes the client from the cache
+func (c *ClientCache) Delete(params CachedClientParams) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	delete(c.cache, params.Key())
+	delete(c.validationHashes, params.Key())
+}

--- a/v3/cache.go
+++ b/v3/cache.go
@@ -40,6 +40,8 @@ type ClientCache struct {
 type CacheOpts func(*ClientCache)
 
 // WithSessionAuth sets the session auth for the ClientCache
+// If sessionAuth is true, the client will use session auth instead of basic auth for authentication of requests
+// If sessionAuth is false, the client will use basic auth for authentication of requests
 func WithSessionAuth(sessionAuth bool) CacheOpts {
 	return func(c *ClientCache) {
 		c.useSessionAuth = sessionAuth
@@ -64,7 +66,11 @@ func NewClientCache(opts ...CacheOpts) *ClientCache {
 // CachedClientParams define the interface that needs to be implemented by an object that will be used to create
 // a cached client.
 type CachedClientParams interface {
+	// ManagementEndpoint returns the struct containing all information needed to construct a new client
+	// and is used to calculate the validation hash for the client for the purpose of cache invalidation.
+	// The validation hash is calculated based on the serialized version of the ManagementEndpoint.
 	ManagementEndpoint() types.ManagementEndpoint
+	// Key returns a unique key for the client that is used to store the client in the cache
 	Key() string
 }
 

--- a/v3/cache_test.go
+++ b/v3/cache_test.go
@@ -1,10 +1,11 @@
 package v3
 
 import (
-	"github.com/nutanix-cloud-native/prism-go-client/environment/types"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/nutanix-cloud-native/prism-go-client/environment/types"
 )
 
 func TestNewClientCacheReturnsNewCache(t *testing.T) {

--- a/v3/cache_test.go
+++ b/v3/cache_test.go
@@ -1,0 +1,94 @@
+package v3
+
+import (
+	"github.com/nutanix-cloud-native/prism-go-client/environment/types"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewClientCacheReturnsNewCache(t *testing.T) {
+	cache := NewClientCache()
+
+	assert.NotNil(t, cache)
+}
+
+type cachedClientParams struct {
+	name         string
+	mgmtEndpoint types.ManagementEndpoint
+}
+
+func (c *cachedClientParams) Key() string {
+	return c.name
+}
+
+func (c *cachedClientParams) ManagementEndpoint() types.ManagementEndpoint {
+	return c.mgmtEndpoint
+}
+
+func TestGetReturnsClientIfPresentInCache(t *testing.T) {
+	cache := NewClientCache()
+	client := &Client{}
+	cache.set("cluster1", "bm90X2FfcmVhbF9oYXNo", client)
+
+	returnedClient, hash, err := cache.get("cluster1")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "bm90X2FfcmVhbF9oYXNo", hash)
+	assert.Equal(t, client, returnedClient)
+}
+
+func TestGetReturnsErrorIfClientNotPresentInCache(t *testing.T) {
+	cache := NewClientCache()
+
+	_, hash, err := cache.get("cluster1")
+
+	assert.Equal(t, "", hash)
+	assert.ErrorIs(t, err, ErrorClientNotFound)
+}
+
+func TestAddAddsClientToCache(t *testing.T) {
+	cache := NewClientCache()
+	client := &Client{}
+
+	cache.set("cluster1", "bm90X2FfcmVhbF9oYXNo", client)
+
+	returnedClient, hash, err := cache.get("cluster1")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "bm90X2FfcmVhbF9oYXNo", hash)
+	assert.Equal(t, client, returnedClient)
+}
+
+func TestAddOverwritesExistingClientInCache(t *testing.T) {
+	cache := NewClientCache()
+	client1 := &Client{}
+	client2 := &Client{}
+
+	cache.set("cluster1", "bm90X2FfcmVhbF9oYXNo", client1)
+	cache.set("cluster1", "ZGVmaW5pdGVseV9ub3RfYV9yZWFsX2hhc2gK", client2)
+
+	returnedClient, hash, err := cache.get("cluster1")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "ZGVmaW5pdGVseV9ub3RfYV9yZWFsX2hhc2gK", hash)
+	assert.Equal(t, client2, returnedClient)
+}
+
+func TestDeleteRemovesClientFromCache(t *testing.T) {
+	cache := NewClientCache()
+	client := &Client{}
+	cache.set("cluster1", "bm90X2FfcmVhbF9oYXNo", client)
+
+	cache.Delete(&cachedClientParams{name: "cluster1"})
+
+	_, hash, err := cache.get("cluster1")
+	assert.Equal(t, "", hash)
+	assert.ErrorIs(t, err, ErrorClientNotFound)
+}
+
+func TestDeleteDoesNotErrorIfClientNotPresentInCache(t *testing.T) {
+	cache := NewClientCache()
+
+	cache.Delete(&cachedClientParams{name: "cluster1"}) // No error expected
+}

--- a/v3/v3.go
+++ b/v3/v3.go
@@ -73,18 +73,28 @@ func WithLogger(logger *logr.Logger) ClientOption {
 	}
 }
 
+// WithUserAgent sets the user agent for the client
+// If set, this will override the default user agent
+func WithUserAgent(userAgent string) ClientOption {
+	return func(c *Client) error {
+		c.clientOpts = append(c.clientOpts, internal.WithUserAgent(userAgent))
+		return nil
+	}
+}
+
 // NewV3Client return a internal to operate V3 resources
 func NewV3Client(credentials prismgoclient.Credentials, opts ...ClientOption) (*Client, error) {
 	if credentials.Username == "" || credentials.Password == "" || credentials.Endpoint == "" {
 		return nil, fmt.Errorf("username, password and endpoint are required")
 	}
 
-	v3Client := &Client{}
-	v3Client.clientOpts = append(v3Client.clientOpts,
-		internal.WithCredentials(&credentials),
-		internal.WithUserAgent(userAgent),
-		internal.WithAbsolutePath(absolutePath),
-	)
+	v3Client := &Client{
+		clientOpts: []internal.ClientOption{
+			internal.WithCredentials(&credentials),
+			internal.WithUserAgent(userAgent),
+			internal.WithAbsolutePath(absolutePath),
+		},
+	}
 
 	for _, opt := range opts {
 		if err := opt(v3Client); err != nil {

--- a/v3/v3_service.go
+++ b/v3/v3_service.go
@@ -867,7 +867,6 @@ func (op Operations) ListAllVM(ctx context.Context, filter string) (*VMListInten
 				Length: utils.Int64Ptr(itemsPerPage),
 				Offset: utils.Int64Ptr(offset),
 			})
-
 			if err != nil {
 				return nil, err
 			}
@@ -909,7 +908,6 @@ func (op Operations) ListAllSubnet(ctx context.Context, filter string, clientSid
 				Length: utils.Int64Ptr(itemsPerPage),
 				Offset: utils.Int64Ptr(offset),
 			})
-
 			if err != nil {
 				return nil, err
 			}
@@ -951,7 +949,6 @@ func (op Operations) ListAllNetworkSecurityRule(ctx context.Context, filter stri
 				Length: utils.Int64Ptr(itemsPerPage),
 				Offset: utils.Int64Ptr(offset),
 			})
-
 			if err != nil {
 				return nil, err
 			}
@@ -993,7 +990,6 @@ func (op Operations) ListAllImage(ctx context.Context, filter string) (*ImageLis
 				Length: utils.Int64Ptr(itemsPerPage),
 				Offset: utils.Int64Ptr(offset),
 			})
-
 			if err != nil {
 				return nil, err
 			}
@@ -1035,7 +1031,6 @@ func (op Operations) ListAllCluster(ctx context.Context, filter string) (*Cluste
 				Length: utils.Int64Ptr(itemsPerPage),
 				Offset: utils.Int64Ptr(offset),
 			})
-
 			if err != nil {
 				return nil, err
 			}
@@ -1077,7 +1072,6 @@ func (op Operations) ListAllCategoryValues(ctx context.Context, categoryName, fi
 				Length: utils.Int64Ptr(itemsPerPage),
 				Offset: utils.Int64Ptr(offset),
 			})
-
 			if err != nil {
 				return nil, err
 			}
@@ -1157,7 +1151,6 @@ func (op Operations) ListAllHost(ctx context.Context) (*HostListResponse, error)
 				Length: utils.Int64Ptr(itemsPerPage),
 				Offset: utils.Int64Ptr(offset),
 			})
-
 			if err != nil {
 				return nil, err
 			}
@@ -1255,7 +1248,6 @@ func (op Operations) ListAllProject(ctx context.Context, filter string) (*Projec
 				Length: utils.Int64Ptr(itemsPerPage),
 				Offset: utils.Int64Ptr(offset),
 			})
-
 			if err != nil {
 				return nil, err
 			}
@@ -1389,7 +1381,6 @@ func (op Operations) ListAllAccessControlPolicy(ctx context.Context, filter stri
 				Length: utils.Int64Ptr(itemsPerPage),
 				Offset: utils.Int64Ptr(offset),
 			})
-
 			if err != nil {
 				return nil, err
 			}
@@ -1524,7 +1515,6 @@ func (op Operations) ListAllRole(ctx context.Context, filter string) (*RoleListR
 				Length: utils.Int64Ptr(itemsPerPage),
 				Offset: utils.Int64Ptr(offset),
 			})
-
 			if err != nil {
 				return nil, err
 			}
@@ -1692,7 +1682,6 @@ func (op Operations) ListAllUser(ctx context.Context, filter string) (*UserListR
 				Length: utils.Int64Ptr(itemsPerPage),
 				Offset: utils.Int64Ptr(offset),
 			})
-
 			if err != nil {
 				return nil, err
 			}
@@ -1787,7 +1776,6 @@ func (op Operations) ListAllUserGroup(ctx context.Context, filter string) (*User
 				Length: utils.Int64Ptr(itemsPerPage),
 				Offset: utils.Int64Ptr(offset),
 			})
-
 			if err != nil {
 				return nil, err
 			}
@@ -1863,7 +1851,6 @@ func (op Operations) ListAllPermission(ctx context.Context, filter string) (*Per
 				Length: utils.Int64Ptr(itemsPerPage),
 				Offset: utils.Int64Ptr(offset),
 			})
-
 			if err != nil {
 				return nil, err
 			}
@@ -1931,7 +1918,6 @@ func (op Operations) ListAllProtectionRules(ctx context.Context, filter string) 
 				Length: utils.Int64Ptr(itemsPerPage),
 				Offset: utils.Int64Ptr(offset),
 			})
-
 			if err != nil {
 				return nil, err
 			}
@@ -2055,7 +2041,6 @@ func (op Operations) ListAllRecoveryPlans(ctx context.Context, filter string) (*
 				Length: utils.Int64Ptr(itemsPerPage),
 				Offset: utils.Int64Ptr(offset),
 			})
-
 			if err != nil {
 				return nil, err
 			}
@@ -2169,7 +2154,6 @@ func (op Operations) ListAllServiceGroups(ctx context.Context, filter string) (*
 				Length: utils.Int64Ptr(itemsPerPage),
 				Offset: utils.Int64Ptr(offset),
 			})
-
 			if err != nil {
 				return nil, err
 			}
@@ -2245,7 +2229,6 @@ func (op Operations) ListAllAddressGroups(ctx context.Context, filter string) (*
 				Length: utils.Int64Ptr(itemsPerPage),
 				Offset: utils.Int64Ptr(offset),
 			})
-
 			if err != nil {
 				return nil, err
 			}

--- a/yamllint-config.yaml
+++ b/yamllint-config.yaml
@@ -1,0 +1,4 @@
+extends: relaxed
+
+rules:
+  line-length: disable


### PR DESCRIPTION
During a recent incident, it was observed that creating a new Nutanix client for each request implies basic authentication for every request. This places unnecessary stress on IAM services. This stress was particularly problematic when the IAM services were already in a degraded state, thereby prolonging recovery efforts. Each basic auth request gets processed through the entire IAM stack, significantly increasing the load and impacting performance.

It's recommend that the client use session-auth cookies instead of basic auth for requests to Prism Central where possible. Session tokens are alive for 15m and then replaced. The session-auth handling mechanism in the client should be resilient to session token refresh. As long the credentials are accurate and session auth mechanism is in play, the client upon receiving the first 401 should refresh the session cookie and retry the request. Only if the requests fails the second time, should the client return a 401 back to the caller.


It's also proposed that we add a cache layer for the users of the library to store long-running clients rather than having to instantiate new ones.

The proposed client cache in the Prism Go client repository includes the following methods:
```
GetOrCreate(clientParams ClientParams) (Client, error): Get a client from cache, if it doesn't exist, create a new one.
Delete(clientParams ClientParams): Remove a client from the cache.
```
If a client already exists but `GetOrCreate` is called with an object that has a different hash from the serialized management endpoint, the cache will delete the old client entry and create a new client with the new management endpoint.

Where ClientParams is defined as the following interface
```
ManagementEndpoint() types.ManagementEndpoint: Structure containing information to instantiate a new client
Key() string: Key for storing the client
```
The Key is the key that would be used to store and retrieve the client while the ManagementEndpoint is the [structure](https://github.com/nutanix-cloud-native/prism-go-client/blob/main/environment/types/types.go#L30-L42) containing all the information needed to create a Client from prism-go-client.
