### PR TITLE
Handle trust bundle presence in management endpoint for v4 client

### DIFF
--- a/v4/cache.go
+++ b/v4/cache.go
@@ -110,6 +110,12 @@ func (c *ClientCache) GetOrCreate(cachedClientParams CachedClientParams, opts ..
 		SessionAuth: c.useSessionAuth,
 	}
 
+	// TODO(sid): v4 SDK doesn't have trust bundle as an input. Until we have a better solution, we will
+	// set Insecure to true if trust bundle is provided to avoid breaking existing consumers of v3 SDK.
+	if cachedClientParams.ManagementEndpoint().AdditionalTrustBundle != "" {
+		credentials.Insecure = true
+	}
+
 	setDefaultsForCredentials(&credentials)
 	if err := validateCredentials(credentials); err != nil {
 		return nil, fmt.Errorf("failed to validate credentials for cachedClientParams with key %s: %w", cachedClientParams.Key(), err)


### PR DESCRIPTION
Set Credentials.Insecure to true in v4 clientCache.GetOrCreate. v4 SDK doesn't have trust bundle as an input. Until we have a better solution, we will set Insecure to true if trust bundle is provided to avoid breaking existing consumers of v3 SDK. This internally would set VerifySSL property of the http client in the v4 client.