### PR TITLE
fix(build): use codecov token through with instead of env

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -44,8 +44,7 @@ jobs:
 
     - name: Codecov
       uses: codecov/codecov-action@v4
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
         file: ./coverage.out  # Replace with the path to your coverage report
         fail_ci_if_error: true
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -130,20 +130,21 @@ clean: ## Remove build related file
 	rm -fr ./bin vendor hack/tools/bin
 	rm -f checkstyle-report.xml ./coverage.out ./profile.cov yamllint-checkstyle.xml
 
+GOTESTPKGS = $(shell go list ./... | grep -v /v3/models)
+
 ## Test:
 test: run-keploy ## Run the tests of the project
 	go test -race -v ./...
 	@$(MAKE) stop-keploy
 
 coverage: run-keploy ## Run the tests of the project and export the coverage
-	go test -race -coverprofile=coverage.out -covermode=atomic ./...
+	go test -race -coverprofile=coverage.out -covermode=atomic $(GOTESTPKGS)
 	@$(MAKE) stop-keploy
 
 ## Lint:
 lint: lint-go lint-yaml lint-kubebuilder ## Run all available linters
 
 lint-go: ## Use golintci-lint on your project
-	$(eval OUTPUT_OPTIONS = $(shell [ "${EXPORT_RESULT}" == "true" ] && echo "--out-format checkstyle ./... | tee /dev/tty > checkstyle-report.xml" || echo "" ))
 	golangci-lint run -v
 
 lint-yaml: ## Use yamllint on the yaml file of your projects


### PR DESCRIPTION
Update makefile to not run coverage on generated model stubs