### PR TITLE
fix(v4): Change the underlying API/Client used for StorageContainers

### DIFF
--- a/devbox.lock
+++ b/devbox.lock
@@ -246,7 +246,8 @@
       }
     },
     "github:NixOS/nixpkgs/nixpkgs-unstable": {
-      "resolved": "github:NixOS/nixpkgs/dd613136ee91f67e5dba3f3f41ac99ae89c5406b?lastModified=1742707865&narHash=sha256-RVQQZy38O3Zb8yoRJhuFgWo%2FiDIDj0hEdRTVfhOtzRk%3D"
+      "last_modified": "2025-05-22T13:30:28Z",
+      "resolved": "github:NixOS/nixpkgs/e314d5c6d3b3a0f40ec5bcbc007b0cbe412f48ae?lastModified=1747920628&narHash=sha256-IlAuXnIi%2BZmyS89tt1YOFDCv7FKs9bNBHd3MXMp8PxE%3D"
     },
     "gnumake@latest": {
       "last_modified": "2024-07-31T08:48:38Z",

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/nutanix/ntnx-api-golang-clients/clustermgmt-go-client/v4 v4.0.1-beta.2
 	github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4 v4.0.2-beta.1
 	github.com/nutanix/ntnx-api-golang-clients/prism-go-client/v4 v4.0.1-beta.1
-	github.com/nutanix/ntnx-api-golang-clients/storage-go-client/v4 v4.0.2-alpha.3
 	github.com/nutanix/ntnx-api-golang-clients/vmm-go-client/v4 v4.0.1-beta.1
 	github.com/nutanix/ntnx-api-golang-clients/volumes-go-client/v4 v4.0.1-beta.1
 	github.com/onsi/ginkgo/v2 v2.19.0

--- a/go.sum
+++ b/go.sum
@@ -351,8 +351,6 @@ github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4 v4.0.2-beta.1
 github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4 v4.0.2-beta.1/go.mod h1:+eZgV1+xL/r84qmuFSVt5R8OFRO70rEz92jOnVgJNco=
 github.com/nutanix/ntnx-api-golang-clients/prism-go-client/v4 v4.0.1-beta.1 h1:hvy3QCc2SgVidYxTq0rRPOazJOt1PP8A86kW7j6sywU=
 github.com/nutanix/ntnx-api-golang-clients/prism-go-client/v4 v4.0.1-beta.1/go.mod h1:Yhk+xD4mN90OKEHnk5ARf97CX5p4+MEC/B/YIVoZeZ0=
-github.com/nutanix/ntnx-api-golang-clients/storage-go-client/v4 v4.0.2-alpha.3 h1:K3I9YtqKcKKxSL4+tcxnFeLOoaptiVlpsOJ9Xzq3shM=
-github.com/nutanix/ntnx-api-golang-clients/storage-go-client/v4 v4.0.2-alpha.3/go.mod h1:kz3gO87xtWnPOCP2kN7yw5LvCDVRnvg8BOWL7CarqXA=
 github.com/nutanix/ntnx-api-golang-clients/vmm-go-client/v4 v4.0.1-beta.1 h1:XuTRvYu1kiNjdXOYVwyjhKlFWyo9nMit6GsOYV8+5Cg=
 github.com/nutanix/ntnx-api-golang-clients/vmm-go-client/v4 v4.0.1-beta.1/go.mod h1:CaWm4GFpAjQQDc6YXl/dUDrHpuW54h8j6Cj7EslE4Qk=
 github.com/nutanix/ntnx-api-golang-clients/volumes-go-client/v4 v4.0.1-beta.1 h1:VJSaQDnnYeNEk1mkQqEbt573OdM62+5s/B0e9kszdas=

--- a/v4/v4.go
+++ b/v4/v4.go
@@ -12,8 +12,6 @@ import (
 	networkingClient "github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4/client"
 	prismApi "github.com/nutanix/ntnx-api-golang-clients/prism-go-client/v4/api"
 	prismClient "github.com/nutanix/ntnx-api-golang-clients/prism-go-client/v4/client"
-	storageApi "github.com/nutanix/ntnx-api-golang-clients/storage-go-client/v4/api"
-	storageClient "github.com/nutanix/ntnx-api-golang-clients/storage-go-client/v4/client"
 	vmApi "github.com/nutanix/ntnx-api-golang-clients/vmm-go-client/v4/api"
 	vmClient "github.com/nutanix/ntnx-api-golang-clients/vmm-go-client/v4/client"
 	volumesApi "github.com/nutanix/ntnx-api-golang-clients/volumes-go-client/v4/api"
@@ -32,7 +30,7 @@ type Client struct {
 	CategoriesApiInstance   *prismApi.CategoriesApi
 	ClustersApiInstance     *clusterApi.ClustersApi
 	ImagesApiInstance       *vmApi.ImagesApi
-	StorageContainerAPI     *storageApi.StorageContainerApi
+	StorageContainerAPI     *clusterApi.StorageContainersApi
 	SubnetsApiInstance      *networkingApi.SubnetsApi
 	SubnetIPReservationApi  *networkingApi.SubnetIPReservationApi
 	TasksApiInstance        *prismApi.TasksApi
@@ -151,13 +149,13 @@ func initStorageApiInstance(v4Client *Client, credentials prismgoclient.Credenti
 	if err != nil {
 		return err
 	}
-	apiClientInstance := storageClient.NewApiClient()
+	apiClientInstance := clusterClient.NewApiClient()
 	apiClientInstance.SetVerifySSL(!credentials.Insecure)
 	apiClientInstance.Host = ep.host
 	apiClientInstance.Port = ep.port
 	apiClientInstance.AddDefaultHeader(
 		authorizationHeader, fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", credentials.Username, credentials.Password)))))
-	v4Client.StorageContainerAPI = storageApi.NewStorageContainerApi(apiClientInstance)
+	v4Client.StorageContainerAPI = clusterApi.NewStorageContainersApi(apiClientInstance)
 	return nil
 }
 


### PR DESCRIPTION
Storage Container APIs seems to have switched namespaces over time. Up until `v4.0.2-alpha.3`, they were in https://github.com/nutanix/ntnx-api-golang-clients/tree/storage-go-client/v4.0.2-alpha.3/storage-go-client as `StorageContainerApi` but in `v4.0.1-beta.2` are under https://github.com/nutanix/ntnx-api-golang-clients/tree/clustermgmt-go-client/v4.0.1-beta.2/clustermgmt-go-client as `StorageContainersApi`.