### PR TITLE
Default Go iterator

### DIFF
--- a/facade/anti_affinity_policies.go
+++ b/facade/anti_affinity_policies.go
@@ -15,7 +15,7 @@ type AntiAffinityPolicyFacadeV4 interface {
 	ListAllAntiAffinityPolicies(filterParam *string, orderbyParam *string) ([]v4policies.VmAntiAffinityPolicy, error)
 
 	// GetListIteratorAntiAffinityPolicies returns an iterator for listing anti-affinity policies.
-	GetListIteratorAntiAffinityPolicies(opts ...ODataOption) (ODataListIterator[v4policies.VmAntiAffinityPolicy], error)
+	GetListIteratorAntiAffinityPolicies(opts ...ODataOption) ODataListIterator[v4policies.VmAntiAffinityPolicy]
 
 	// CreateAntiAffinityPolicy creates a new anti-affinity policy.
 	CreateAntiAffinityPolicy(policy v4policies.VmAntiAffinityPolicy) (TaskWaiter[v4policies.VmAntiAffinityPolicy], error)

--- a/facade/categories.go
+++ b/facade/categories.go
@@ -15,7 +15,7 @@ type CategoriesFacadeV4 interface {
 	ListAllCategories(filterParam *string, orderbyParam *string, expandParam *string, selectParam *string) ([]v4prismModels.Category, error)
 
 	// GetListIteratorCategories returns an iterator for listing categories.
-	GetListIteratorCategories(opts ...ODataOption) (ODataListIterator[v4prismModels.Category], error)
+	GetListIteratorCategories(opts ...ODataOption) ODataListIterator[v4prismModels.Category]
 
 	// CreateCategory creates a new category.
 	CreateCategory(category *v4prismModels.Category) (*v4prismModels.Category, error)

--- a/facade/clusters.go
+++ b/facade/clusters.go
@@ -15,7 +15,7 @@ type ClustersFacadeV4 interface {
 	ListAllClusters(filterParam *string, orderbyParam *string, expandParam *string, selectParam *string) ([]clusterModels.Cluster, error)
 
 	// GetListIteratorClusters returns an iterator for listing clusters.
-	GetListIteratorClusters(opts ...ODataOption) (ODataListIterator[clusterModels.Cluster], error)
+	GetListIteratorClusters(opts ...ODataOption) ODataListIterator[clusterModels.Cluster]
 
 	// ListClusterVirtualGPUs returns the virtual GPU configuration for the given cluster UUID.
 	ListClusterVirtualGPUs(clusterUuid string, opts ...ODataOption) ([]clusterModels.VirtualGpuProfile, error)

--- a/facade/facade.go
+++ b/facade/facade.go
@@ -1,5 +1,7 @@
 package facade
 
+import "iter"
+
 type FacadeClientV4 interface {
 	AntiAffinityPolicyFacadeV4
 	CategoriesFacadeV4
@@ -93,8 +95,12 @@ func NoEntityGetter(uuid string) (*NoEntity, error) {
 	return nil, nil
 }
 
-type ODataListIterator[T any] interface {
-	Next() bool
-	GetCurrent() (T, error)
-	Count() int
-}
+// make it more Go-ish style iterator
+type ODataListIterator[T any] iter.Seq2[T, error]
+
+//
+// 1. Error handling
+// 2. Go iterator
+// 3. Naming
+// 4. Context in every API call
+//

--- a/facade/images.go
+++ b/facade/images.go
@@ -15,5 +15,5 @@ type ImagesFacadeV4 interface {
 	ListAllImages(filterParam *string, orderbyParam *string, selectParam *string) ([]imageModels.Image, error)
 
 	// GetListIteratorImages returns an iterator for listing images.
-	GetListIteratorImages(opts ...ODataOption) (ODataListIterator[imageModels.Image], error)
+	GetListIteratorImages(opts ...ODataOption) ODataListIterator[imageModels.Image]
 }

--- a/facade/storage_containers.go
+++ b/facade/storage_containers.go
@@ -1,20 +1,20 @@
 package facade
 
 import (
-	storageContainerModels "github.com/nutanix/ntnx-api-golang-clients/clustermgmt-go-client/v4/models/clustermgmt/v4/config"
+	scmodels "github.com/nutanix/ntnx-api-golang-clients/clustermgmt-go-client/v4/models/clustermgmt/v4/config"
 )
 
 // StorageContainersFacadeV4 defines the interface for managing storage containers.
 type StorageContainersFacadeV4 interface {
 	// GetStorageContainer returns the storage container for the given UUID.
-	GetStorageContainer(uuid string) (*storageContainerModels.StorageContainer, error)
+	GetStorageContainer(uuid string) (*scmodels.StorageContainer, error)
 
 	// ListStorageContainers returns a list of storage containers.
-	ListStorageContainers(opts ...ODataOption) ([]storageContainerModels.StorageContainer, error)
+	ListStorageContainers(opts ...ODataOption) ([]scmodels.StorageContainer, error)
 
 	// ListAllStorageContainers returns all storage containers without pagination.
-	ListAllStorageContainers(filterParam *string, orderbyParam *string, selectParam *string) ([]storageContainerModels.StorageContainer, error)
+	ListAllStorageContainers(filterParam *string, orderbyParam *string, selectParam *string) ([]scmodels.StorageContainer, error)
 
 	// GetListIteratorStorageContainers returns an iterator for listing storage containers.
-	GetListIteratorStorageContainers(opts ...ODataOption) (ODataListIterator[storageContainerModels.StorageContainer], error)
+	GetListIteratorStorageContainers(opts ...ODataOption) ODataListIterator[scmodels.StorageContainer]
 }

--- a/facade/subnets.go
+++ b/facade/subnets.go
@@ -15,5 +15,5 @@ type SubnetsFacadeV4 interface {
 	ListAllSubnets(filterParam *string, orderbyParam *string, expandParam *string, selectParam *string) ([]subnetModels.Subnet, error)
 
 	// GetListIteratorSubnets returns an iterator for listing subnets.
-	GetListIteratorSubnets(opts ...ODataOption) (ODataListIterator[subnetModels.Subnet], error)
+	GetListIteratorSubnets(opts ...ODataOption) ODataListIterator[subnetModels.Subnet]
 }

--- a/facade/v4/anti_affinity_policies.go
+++ b/facade/v4/anti_affinity_policies.go
@@ -53,7 +53,7 @@ func (f *FacadeV4Client) ListAllAntiAffinityPolicies(filterParam *string, orderb
 	)
 }
 
-func (f *FacadeV4Client) GetListIteratorAntiAffinityPolicies(opts ...facade.ODataOption) (facade.ODataListIterator[v4policies.VmAntiAffinityPolicy], error) {
+func (f *FacadeV4Client) GetListIteratorAntiAffinityPolicies(opts ...facade.ODataOption) facade.ODataListIterator[v4policies.VmAntiAffinityPolicy] {
 	return CommonGetListIterator[*v4policies.ListVmAntiAffinityPoliciesApiResponse, v4policies.VmAntiAffinityPolicy](
 		f,
 		func(reqParams *V4ODataParams) (*v4policies.ListVmAntiAffinityPoliciesApiResponse, error) {

--- a/facade/v4/categories.go
+++ b/facade/v4/categories.go
@@ -64,7 +64,7 @@ func (f *FacadeV4Client) ListAllCategories(filterParam *string, orderbyParam *st
 }
 
 // GetListIteratorCategories returns an iterator for listing categories.
-func (f *FacadeV4Client) GetListIteratorCategories(opts ...facade.ODataOption) (facade.ODataListIterator[v4prismModels.Category], error) {
+func (f *FacadeV4Client) GetListIteratorCategories(opts ...facade.ODataOption) facade.ODataListIterator[v4prismModels.Category] {
 	return CommonGetListIterator[*v4prismModels.ListCategoriesApiResponse, v4prismModels.Category](
 		f,
 		func(reqParams *V4ODataParams) (*v4prismModels.ListCategoriesApiResponse, error) {

--- a/facade/v4/clusters.go
+++ b/facade/v4/clusters.go
@@ -61,7 +61,7 @@ func (f *FacadeV4Client) ListAllClusters(filterParam *string, orderbyParam *stri
 }
 
 // GetListIteratorClusters returns an iterator for listing clusters.
-func (f *FacadeV4Client) GetListIteratorClusters(opts ...facade.ODataOption) (facade.ODataListIterator[clustersModels.Cluster], error) {
+func (f *FacadeV4Client) GetListIteratorClusters(opts ...facade.ODataOption) facade.ODataListIterator[clustersModels.Cluster] {
 	return CommonGetListIterator[*clustersModels.ListClustersApiResponse, clustersModels.Cluster](
 		f,
 		func(reqParams *V4ODataParams) (*clustersModels.ListClustersApiResponse, error) {

--- a/facade/v4/common.go
+++ b/facade/v4/common.go
@@ -60,28 +60,12 @@ func CommonListAllEntities[R APIResponse, T any](apiCall func(reqParams *V4OData
 	return result, nil
 }
 
-func CommonGetListIterator[R APIResponse, T any](f *FacadeV4Client, apiCall func(reqParams *V4ODataParams) (R, error), options []facade.ODataOption, entitiesName string) (facade.ODataListIterator[T], error) {
-	reqParams, err := OptsToV4ODataParams(options...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to convert options to V4 OData params: %w", err)
-	}
-
-	page := 0
-	reqParams.Limit = nil  // Let API use the default limit
-	reqParams.Page = &page // Start from the page 0
-
-	itemsBuffer, totalCount, err := CallListAPI[R, T](apiCall(reqParams))
-	if err != nil {
-		return nil, fmt.Errorf("failed to get list iterator for %s: %w", entitiesName, err)
-	}
-
-	return NewFacadeV4ODataIterator(
+func CommonGetListIterator[R APIResponse, T any](f *FacadeV4Client, apiCall func(reqParams *V4ODataParams) (R, error), options []facade.ODataOption, entitiesName string) facade.ODataListIterator[T] {
+	return NewFacadeV4ODataIterator[R, T](
 		f.client,
-		totalCount,
-		itemsBuffer,
 		func(reqParams *V4ODataParams) (R, error) {
 			return apiCall(reqParams)
 		},
 		options...,
-	), nil
+	)
 }

--- a/facade/v4/images.go
+++ b/facade/v4/images.go
@@ -56,7 +56,7 @@ func (f *FacadeV4Client) ListAllImages(filterParam *string, orderbyParam *string
 }
 
 // GetListIteratorImages returns an iterator for listing images.
-func (f *FacadeV4Client) GetListIteratorImages(opts ...facade.ODataOption) (facade.ODataListIterator[imageModels.Image], error) {
+func (f *FacadeV4Client) GetListIteratorImages(opts ...facade.ODataOption) facade.ODataListIterator[imageModels.Image] {
 	return CommonGetListIterator[*imageModels.ListImagesApiResponse, imageModels.Image](
 		f,
 		func(reqParams *V4ODataParams) (*imageModels.ListImagesApiResponse, error) {

--- a/facade/v4/storage_containers.go
+++ b/facade/v4/storage_containers.go
@@ -56,7 +56,7 @@ func (f *FacadeV4Client) ListAllStorageContainers(filterParam *string, orderbyPa
 }
 
 // GetListIteratorStorageContainers returns an iterator for listing storage containers.
-func (f *FacadeV4Client) GetListIteratorStorageContainers(opts ...facade.ODataOption) (facade.ODataListIterator[storageContainerModels.StorageContainer], error) {
+func (f *FacadeV4Client) GetListIteratorStorageContainers(opts ...facade.ODataOption) facade.ODataListIterator[storageContainerModels.StorageContainer] {
 	return CommonGetListIterator[*storageContainerModels.ListStorageContainersApiResponse, storageContainerModels.StorageContainer](
 		f,
 		func(reqParams *V4ODataParams) (*storageContainerModels.ListStorageContainersApiResponse, error) {

--- a/facade/v4/subnets.go
+++ b/facade/v4/subnets.go
@@ -59,7 +59,7 @@ func (f *FacadeV4Client) ListAllSubnets(filterParam *string, orderbyParam *strin
 }
 
 // GetListIteratorSubnets returns an iterator for listing subnets.
-func (f *FacadeV4Client) GetListIteratorSubnets(opts ...facade.ODataOption) (facade.ODataListIterator[subnetModels.Subnet], error) {
+func (f *FacadeV4Client) GetListIteratorSubnets(opts ...facade.ODataOption) facade.ODataListIterator[subnetModels.Subnet] {
 	return CommonGetListIterator[*subnetModels.ListSubnetsApiResponse, subnetModels.Subnet](
 		f,
 		func(reqParams *V4ODataParams) (*subnetModels.ListSubnetsApiResponse, error) {

--- a/facade/v4/utils.go
+++ b/facade/v4/utils.go
@@ -203,7 +203,7 @@ func CallListAPI[R APIResponse, T any](response R, err error) ([]T, int, error) 
 		return zero, 0, fmt.Errorf("API call failed: %w", err)
 	}
 
-	totalCount, err := GetMetadataTotalResults[R](response)
+	totalCount, err := GetMetadataTotalResults(response)
 	if err != nil {
 		return zero, 0, fmt.Errorf("failed to get total results from response metadata: %w", err)
 	}

--- a/facade/vms.go
+++ b/facade/vms.go
@@ -15,7 +15,7 @@ type VMsFacadeV4 interface {
 	ListAllVMs(filterParam *string, orderbyParam *string, selectParam *string) ([]vmmModels.Vm, error)
 
 	// GetListIteratorVMs returns an iterator for listing VMs.
-	GetListIteratorVMs(opts ...ODataOption) (ODataListIterator[vmmModels.Vm], error)
+	GetListIteratorVMs(opts ...ODataOption) ODataListIterator[vmmModels.Vm]
 
 	// CreateVM creates a new VM.
 	CreateVM(vm *vmmModels.Vm) (TaskWaiter[vmmModels.Vm], error)

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/nutanix-cloud-native/prism-go-client
 
-go 1.21
+go 1.23
 
-toolchain go1.22.2
+toolchain go1.23.0
 
 require (
 	github.com/PaesslerAG/jsonpath v0.1.1


### PR DESCRIPTION
Change iterator to Go default iterator

Usage example:
```go
	vms := client.GetListIteratorVMs()
	for vm, err := range vms {
		if err != nil {
			fmt.Printf("Error getting next VM: %v\n", err)
			return
		}
		fmt.Printf("VM Name: %s, UUID: %s\n", *vm.Name, *vm.ExtId)
	}
```