### PR TITLE
fix: Correctly list all hosts

### DIFF
--- a/v3/v3_service.go
+++ b/v3/v3_service.go
@@ -1136,38 +1136,13 @@ func (op Operations) ListHost(ctx context.Context, getEntitiesRequest *DSMetadat
 
 // ListAllHost ...
 func (op Operations) ListAllHost(ctx context.Context) (*HostListResponse, error) {
-	entities := make([]*HostResponse, 0)
-
 	resp, err := op.ListHost(ctx, &DSMetadata{
-		Kind:   ptr.To("host"),
-		Length: ptr.To(itemsPerPage),
+		Kind: ptr.To("host"),
+		// We omit the Length parameter, because ListHost does not support pagination,
+		// and returns all hosts.
 	})
 	if err != nil {
 		return nil, err
-	}
-
-	totalEntities := ptr.Deref(resp.Metadata.TotalMatches, 0)
-	remaining := totalEntities
-	offset := ptr.Deref(resp.Metadata.Offset, 0)
-
-	if totalEntities > itemsPerPage {
-		for hasNext(&remaining) {
-			resp, err = op.ListHost(ctx, &DSMetadata{
-				Kind:   ptr.To("cluster"),
-				Length: ptr.To(itemsPerPage),
-				Offset: ptr.To(offset),
-			})
-			if err != nil {
-				return nil, err
-			}
-
-			entities = append(entities, resp.Entities...)
-
-			offset += itemsPerPage
-			log.Printf("[Debug] total=%d, remaining=%d, offset=%d len(entities)=%d\n", totalEntities, remaining, offset, len(entities))
-		}
-
-		resp.Entities = entities
 	}
 
 	return resp, nil

--- a/v3/v3_service.go
+++ b/v3/v3_service.go
@@ -1753,7 +1753,7 @@ func (op Operations) ListAllUserGroup(ctx context.Context, filter string) (*User
 		for hasNext(&remaining) {
 			resp, err = op.ListUserGroup(ctx, &DSMetadata{
 				Filter: &filter,
-				Kind:   ptr.To("user"),
+				Kind:   ptr.To("user_group"),
 				Length: ptr.To(itemsPerPage),
 				Offset: ptr.To(offset),
 			})


### PR DESCRIPTION
There was a typo that ended up passing the wrong Kind (`cluster`, instead of `host`) in follow-up requests when handling pagination. However, I also learned that the "list hosts" endpoint [does not support pagination](https://next.nutanix.com/ahv-virtualization-27/regarding-the-pagination-not-working-for-v3-hosts-endpoint-of-prism-central-41910). I confirmed that the endpoint in fact does not support pagination. I removed the pagination code.

The client always requests 100 hosts at once, and assumes the response is paginated. The client pagination logic is triggered whenever there are > 100 hosts. In that case, the client will make approximately (number of hosts)/100 requests.

As I was looking into the typo bug, I found a second instance of it for the "list user groups" endpoint. The fix is included as a separate commit.
 
