### PR TITLE
fix: Add UUID in the URL path for UpdateK8sRegistration

### DIFF
--- a/konnector/konnector_cluster_registration_service.go
+++ b/konnector/konnector_cluster_registration_service.go
@@ -19,7 +19,7 @@ type ClusterRegistrationOperations struct {
 type ClusterRegistrationService interface {
 	// Cluster Registration
 	CreateK8sRegistration(ctx context.Context, createRequest *K8sCreateClusterRegistrationRequest) (*K8sCreateClusterRegistrationResponse, error)
-	UpdateK8sRegistration(ctx context.Context, k8sClusterUUID string, updateRequest *K8sClusterKubeconfigUpdateRequest) (*K8sClusterKubeconfigUpdateResponse, error)
+	UpdateK8sRegistration(ctx context.Context, k8sClusterUUID string, updateRequest *K8sClusterUpdateRequest) (*K8sClusterUpdateResponse, error)
 	DeleteK8sRegistration(ctx context.Context, uuid string, params DeleteK8sRegistrationParams) (*K8sClusterRegistrationDeleteResponse, error)
 	DeleteK8sRegistrationKubeconfig(ctx context.Context, uuid string, params DeleteK8sRegistrationKubeconfigParams) (*K8sClusterKubeconfigDeleteResponse, error)
 	GetK8sRegistration(ctx context.Context, UUID string) (*K8sClusterRegistration, error)
@@ -43,17 +43,17 @@ func (op ClusterRegistrationOperations) CreateK8sRegistration(ctx context.Contex
 	return k8sCreateClusterRegistrationResponse, nil
 }
 
-func (op ClusterRegistrationOperations) UpdateK8sRegistration(ctx context.Context, k8sClusterUUID string, updateRequest *K8sClusterKubeconfigUpdateRequest) (*K8sClusterKubeconfigUpdateResponse, error) {
+func (op ClusterRegistrationOperations) UpdateK8sRegistration(ctx context.Context, k8sClusterUUID string, updateRequest *K8sClusterUpdateRequest) (*K8sClusterUpdateResponse, error) {
 	path := "/v1-alpha.1/k8s/cluster-registrations/" + k8sClusterUUID
 	req, err := op.httpClient.NewRequest(http.MethodPatch, path, updateRequest)
 	if err != nil {
 		return nil, err
 	}
-	k8sClusterKubeconfigUpdateResponse := new(K8sClusterKubeconfigUpdateResponse)
-	if err := op.httpClient.Do(ctx, req, k8sClusterKubeconfigUpdateResponse); err != nil {
+	k8sClusterUpdateResponse := new(K8sClusterUpdateResponse)
+	if err := op.httpClient.Do(ctx, req, k8sClusterUpdateResponse); err != nil {
 		return nil, err
 	}
-	return k8sClusterKubeconfigUpdateResponse, nil
+	return k8sClusterUpdateResponse, nil
 }
 
 // DeleteK8sRegistration deletes the k8s registration with UUID

--- a/konnector/konnector_cluster_registration_service.go
+++ b/konnector/konnector_cluster_registration_service.go
@@ -19,7 +19,7 @@ type ClusterRegistrationOperations struct {
 type ClusterRegistrationService interface {
 	// Cluster Registration
 	CreateK8sRegistration(ctx context.Context, createRequest *K8sCreateClusterRegistrationRequest) (*K8sCreateClusterRegistrationResponse, error)
-	UpdateK8sRegistration(ctx context.Context, updaetRequest *PatchK8sClusterRegistrationParams) (*K8sClusterKubeconfigUpdateResponse, error)
+	UpdateK8sRegistration(ctx context.Context, k8sClusterUUID string, updateRequest *K8sClusterKubeconfigUpdateRequest) (*K8sClusterKubeconfigUpdateResponse, error)
 	DeleteK8sRegistration(ctx context.Context, uuid string, params DeleteK8sRegistrationParams) (*K8sClusterRegistrationDeleteResponse, error)
 	DeleteK8sRegistrationKubeconfig(ctx context.Context, uuid string, params DeleteK8sRegistrationKubeconfigParams) (*K8sClusterKubeconfigDeleteResponse, error)
 	GetK8sRegistration(ctx context.Context, UUID string) (*K8sClusterRegistration, error)
@@ -43,9 +43,9 @@ func (op ClusterRegistrationOperations) CreateK8sRegistration(ctx context.Contex
 	return k8sCreateClusterRegistrationResponse, nil
 }
 
-func (op ClusterRegistrationOperations) UpdateK8sRegistration(ctx context.Context, updaetRequest *PatchK8sClusterRegistrationParams) (*K8sClusterKubeconfigUpdateResponse, error) {
-	path := "/v1-alpha.1/k8s/cluster-registrations/"
-	req, err := op.httpClient.NewRequest(http.MethodPatch, path, updaetRequest)
+func (op ClusterRegistrationOperations) UpdateK8sRegistration(ctx context.Context, k8sClusterUUID string, updateRequest *K8sClusterKubeconfigUpdateRequest) (*K8sClusterKubeconfigUpdateResponse, error) {
+	path := "/v1-alpha.1/k8s/cluster-registrations/" + k8sClusterUUID
+	req, err := op.httpClient.NewRequest(http.MethodPatch, path, updateRequest)
 	if err != nil {
 		return nil, err
 	}

--- a/konnector/konnector_cluster_registration_service_test.go
+++ b/konnector/konnector_cluster_registration_service_test.go
@@ -277,12 +277,12 @@ func TestKonnectorUpdateClusterRegistration(t *testing.T) {
 
 	// Construct patch request to update kubeconfig or metadata
 	base64EncodedKubeconfig := "c2FtcGxla3ViZWNvbmZpZw=="
-	kubeConfig := &K8sClusterKubeconfigUpdateRequest{
+	updateRequest := &K8sClusterUpdateRequest{
 		Kubeconfig: &base64EncodedKubeconfig,
 	}
 
 	// Call the Update (PATCH) operation - UUID is now in URL path
-	responseUpdate, err := konnectorClient.ClusterRegistrationOperations.UpdateK8sRegistration(kctx, test_cluster_uuid, kubeConfig)
+	responseUpdate, err := konnectorClient.ClusterRegistrationOperations.UpdateK8sRegistration(kctx, test_cluster_uuid, updateRequest)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, *responseUpdate.TaskUUID)
 	require.NotNil(t, responseUpdate.TaskUUID)

--- a/konnector/konnector_cluster_registration_service_test.go
+++ b/konnector/konnector_cluster_registration_service_test.go
@@ -281,13 +281,8 @@ func TestKonnectorUpdateClusterRegistration(t *testing.T) {
 		Kubeconfig: &base64EncodedKubeconfig,
 	}
 
-	updateReq := &PatchK8sClusterRegistrationParams{
-		ID:   test_cluster_uuid,
-		Body: kubeConfig,
-	}
-
-	// Call the Update (PATCH) operation
-	responseUpdate, err := konnectorClient.ClusterRegistrationOperations.UpdateK8sRegistration(kctx, updateReq)
+	// Call the Update (PATCH) operation - UUID is now in URL path
+	responseUpdate, err := konnectorClient.ClusterRegistrationOperations.UpdateK8sRegistration(kctx, test_cluster_uuid, kubeConfig)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, *responseUpdate.TaskUUID)
 	require.NotNil(t, responseUpdate.TaskUUID)

--- a/konnector/konnector_cluster_registration_structs.go
+++ b/konnector/konnector_cluster_registration_structs.go
@@ -222,7 +222,7 @@ type PatchK8sClusterRegistrationParams struct {
 	  Required: true
 	  In: body
 	*/
-	Body *K8sClusterKubeconfigUpdateRequest
+	Body *K8sClusterUpdateRequest
 	/*Kubernetes cluster registration UUID.
 	  Required: true
 	  In: path
@@ -230,13 +230,15 @@ type PatchK8sClusterRegistrationParams struct {
 	ID string
 }
 
-type K8sClusterKubeconfigUpdateRequest struct {
+// K8sClusterUpdateRequest k8s cluster update request
+type K8sClusterUpdateRequest struct {
 	// Base64 encoded kubeconfig YAML content
 	// Required: true
 	Kubeconfig *string `json:"kubeconfig"`
 }
 
-type K8sClusterKubeconfigUpdateResponse struct {
+// K8sClusterUpdateResponse k8s cluster update response
+type K8sClusterUpdateResponse struct {
 	// task uuid
 	// Required: true
 	TaskUUID *string `json:"task_uuid"`

--- a/konnector/mocks/TestKonnectorUpdateClusterRegistration.yaml
+++ b/konnector/mocks/TestKonnectorUpdateClusterRegistration.yaml
@@ -154,14 +154,14 @@ spec:
         method: PATCH
         proto_major: 1
         proto_minor: 1
-        url: https://prism.nutanix.local:9440/karbon/v1-alpha.1/k8s/cluster-registrations/
+        url: https://prism.nutanix.local:9440/karbon/v1-alpha.1/k8s/cluster-registrations/634f5852-ce1b-465c-a95a-9b8dffbdde42
         header:
             Accept: application/json
             Authorization: Basic YWRtaW46TnV0YW5peC4xMjM=
             Content-Type: application/json
             User-Agent: nutanix
         body: |
-            {"Body":{"kubeconfig":"c2FtcGxla3ViZWNvbmZpZw=="},"ID":"634f5852-ce1b-465c-a95a-9b8dffbdde42"}
+            {"kubeconfig":"c2FtcGxla3ViZWNvbmZpZw=="}
         body_type: utf-8
     resp:
         status_code: 202


### PR DESCRIPTION
Updated UpdateK8sRegistration implementation in prism-go-client
- UUID is now included in the URL path instead of request body.

## Why This Change is Needed
- Existing SDK implementation targets an unsupported API endpoint.
- Passing UUID in body does NOT work (verified via curl testing).
```
curl -k -u "BXjYAehPQrFC:j68S17gqsMO30Ccr9lFaNmRP24hwGfb5" \
-X PATCH \
"https://10.22.167.76:9440/karbon/v1-alpha.1/k8s/cluster-registrations" \ 
-H "Content-Type: application/json" \
-d '{
  "id": "'80a29c85-9a5b-46e7-8320-f1919ebd0a77'",
  "kubeconfig": "TEST"
}'

{"code":405,"message":"method PATCH is not allowed, but [GET,POST] are"}%
```
- Passing UUID in the URL path works
```
curl -k -u "BXjYAehPQrFC:j68S17gqsMO30Ccr9lFaNmRP24hwGfb5" \
-X PATCH \
"https://10.22.167.76:9440/karbon/v1-alpha.1/k8s/cluster-registrations/80a29c85-9a5b-46e7-8320-f1919ebd0a77" \
-H "Content-Type: application/json" \
-d '{
  "kubeconfig": "TEST"
}'

{"task_uuid":"b1c3901d-2fe5-4d9d-440f-204922058274"}
```