### PR TITLE
fix:  ETag handling for protection policy and recovery plan deletions

### DIFF
--- a/converged/v4/protection_policies.go
+++ b/converged/v4/protection_policies.go
@@ -125,8 +125,8 @@ func (s *ProtectionPoliciesService) CreateAsync(ctx context.Context, policy *dpM
 	if err != nil {
 		return nil, fmt.Errorf("failed to create %s: %w", s.entitiesName, err)
 	}
-	taskRef, err := CallAPI[*dpModels.CreateProtectionPolicyApiResponse, *dpPrism.TaskReference](resp, err)
-	if err != nil || taskRef == nil {
+	taskRef, err := CallAPI[*dpModels.CreateProtectionPolicyApiResponse, dpPrism.TaskReference](resp, err)
+	if err != nil {
 		return nil, fmt.Errorf("failed to create %s: %w", s.entitiesName, err)
 	}
 	if taskRef.ExtId == nil {
@@ -163,8 +163,8 @@ func (s *ProtectionPoliciesService) UpdateAsync(ctx context.Context, uuid string
 	if err != nil {
 		return nil, fmt.Errorf("failed to update %s: %w", s.entitiesName, err)
 	}
-	taskRef, err := CallAPI[*dpModels.UpdateProtectionPolicyApiResponse, *dpPrism.TaskReference](resp, err)
-	if err != nil || taskRef == nil {
+	taskRef, err := CallAPI[*dpModels.UpdateProtectionPolicyApiResponse, dpPrism.TaskReference](resp, err)
+	if err != nil {
 		return nil, fmt.Errorf("failed to update %s: %w", s.entitiesName, err)
 	}
 	if taskRef.ExtId == nil {
@@ -191,12 +191,18 @@ func (s *ProtectionPoliciesService) DeleteAsync(ctx context.Context, uuid string
 	if s.client == nil {
 		return nil, errors.New("client is not initialized")
 	}
-	resp, err := s.client.ProtectionPoliciesApiInstance.DeleteProtectionPolicyById(&uuid, nil)
+	_, args, err := GetEntityAndEtag(
+		s.client.ProtectionPoliciesApiInstance.GetProtectionPolicyById(&uuid, nil),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get %s for deletion: %w", s.entitiesName, err)
+	}
+	resp, err := s.client.ProtectionPoliciesApiInstance.DeleteProtectionPolicyById(&uuid, args)
 	if err != nil {
 		return nil, fmt.Errorf("failed to delete %s: %w", s.entitiesName, err)
 	}
-	taskRef, err := CallAPI[*dpModels.DeleteProtectionPolicyApiResponse, *dpPrism.TaskReference](resp, err)
-	if err != nil || taskRef == nil {
+	taskRef, err := CallAPI[*dpModels.DeleteProtectionPolicyApiResponse, dpPrism.TaskReference](resp, err)
+	if err != nil {
 		return nil, fmt.Errorf("failed to delete %s: %w", s.entitiesName, err)
 	}
 	if taskRef.ExtId == nil {

--- a/converged/v4/protection_policies_test.go
+++ b/converged/v4/protection_policies_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/nutanix-cloud-native/prism-go-client/converged"
 	"github.com/nutanix-cloud-native/prism-go-client/internal/testhelpers"
+	v4prismGoClient "github.com/nutanix-cloud-native/prism-go-client/v4"
 
 	dpModels "github.com/nutanix/ntnx-api-golang-clients/datapolicies-go-client/v4/models/datapolicies/v4/config"
 )
@@ -157,39 +158,32 @@ func TestProtectionPoliciesService_ErrorHandling(t *testing.T) {
 
 // TestProtectionPoliciesService_UnsupportedODataOptions tests that apply and expand options are rejected.
 func TestProtectionPoliciesService_UnsupportedODataOptions(t *testing.T) {
-	creds := testhelpers.CredentialsFromEnvironment(t)
-	if strings.Contains(creds.Endpoint, prismEndpointDummyValue) {
-		t.Skip("Skipping integration test: NUTANIX_ENDPOINT not set")
-	}
-
-	client, err := NewClient(creds)
-	require.NoError(t, err)
-	require.NotNil(t, client)
-
+	service := NewProtectionPoliciesService(&v4prismGoClient.Client{})
+	require.NotNil(t, service)
 	ctx := context.Background()
 
 	t.Run("List_WithExpand", func(t *testing.T) {
-		_, err := client.DataPolicies.ProtectionPolicies.List(ctx, converged.WithExpand("config"))
+		_, err := service.List(ctx, converged.WithExpand("config"))
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "apply and expand options are not supported for listing")
 		assert.Contains(t, err.Error(), "protection policy")
 	})
 
 	t.Run("List_WithApply", func(t *testing.T) {
-		_, err := client.DataPolicies.ProtectionPolicies.List(ctx, converged.WithApply("groupby((extId))"))
+		_, err := service.List(ctx, converged.WithApply("groupby((extId))"))
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "apply and expand options are not supported for listing")
 		assert.Contains(t, err.Error(), "protection policy")
 	})
 
 	t.Run("List_WithExpandAndLimit", func(t *testing.T) {
-		_, err := client.DataPolicies.ProtectionPolicies.List(ctx, converged.WithExpand("config"), converged.WithLimit(5))
+		_, err := service.List(ctx, converged.WithExpand("config"), converged.WithLimit(5))
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "apply and expand options are not supported for listing")
 	})
 
 	t.Run("NewIterator_WithExpand", func(t *testing.T) {
-		iter := client.DataPolicies.ProtectionPolicies.NewIterator(ctx, converged.WithExpand("config"))
+		iter := service.NewIterator(ctx, converged.WithExpand("config"))
 		require.NotNil(t, iter)
 
 		var gotError error
@@ -202,7 +196,7 @@ func TestProtectionPoliciesService_UnsupportedODataOptions(t *testing.T) {
 	})
 
 	t.Run("NewIterator_WithApply", func(t *testing.T) {
-		iter := client.DataPolicies.ProtectionPolicies.NewIterator(ctx, converged.WithApply("groupby((extId))"))
+		iter := service.NewIterator(ctx, converged.WithApply("groupby((extId))"))
 		require.NotNil(t, iter)
 
 		var gotError error

--- a/converged/v4/recovery_plans.go
+++ b/converged/v4/recovery_plans.go
@@ -125,8 +125,8 @@ func (s *RecoveryPlansService) CreateAsync(ctx context.Context, plan *dpModels.R
 	if err != nil {
 		return nil, fmt.Errorf("failed to create %s: %w", s.entitiesName, err)
 	}
-	taskRef, err := CallAPI[*dpModels.CreateRecoveryPlanApiResponse, *dpPrism.TaskReference](resp, err)
-	if err != nil || taskRef == nil {
+	taskRef, err := CallAPI[*dpModels.CreateRecoveryPlanApiResponse, dpPrism.TaskReference](resp, err)
+	if err != nil {
 		return nil, fmt.Errorf("failed to create %s: %w", s.entitiesName, err)
 	}
 	if taskRef.ExtId == nil {
@@ -163,8 +163,8 @@ func (s *RecoveryPlansService) UpdateAsync(ctx context.Context, uuid string, pla
 	if err != nil {
 		return nil, fmt.Errorf("failed to update %s: %w", s.entitiesName, err)
 	}
-	taskRef, err := CallAPI[*dpModels.UpdateRecoveryPlanApiResponse, *dpPrism.TaskReference](resp, err)
-	if err != nil || taskRef == nil {
+	taskRef, err := CallAPI[*dpModels.UpdateRecoveryPlanApiResponse, dpPrism.TaskReference](resp, err)
+	if err != nil {
 		return nil, fmt.Errorf("failed to update %s: %w", s.entitiesName, err)
 	}
 	if taskRef.ExtId == nil {
@@ -191,12 +191,18 @@ func (s *RecoveryPlansService) DeleteAsync(ctx context.Context, uuid string) (co
 	if s.client == nil {
 		return nil, errors.New("client is not initialized")
 	}
-	resp, err := s.client.RecoveryPlansApiInstance.DeleteRecoveryPlanById(&uuid, nil)
+	_, args, err := GetEntityAndEtag(
+		s.client.RecoveryPlansApiInstance.GetRecoveryPlanById(&uuid, nil),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get %s for deletion: %w", s.entitiesName, err)
+	}
+	resp, err := s.client.RecoveryPlansApiInstance.DeleteRecoveryPlanById(&uuid, args)
 	if err != nil {
 		return nil, fmt.Errorf("failed to delete %s: %w", s.entitiesName, err)
 	}
-	taskRef, err := CallAPI[*dpModels.DeleteRecoveryPlanApiResponse, *dpPrism.TaskReference](resp, err)
-	if err != nil || taskRef == nil {
+	taskRef, err := CallAPI[*dpModels.DeleteRecoveryPlanApiResponse, dpPrism.TaskReference](resp, err)
+	if err != nil {
 		return nil, fmt.Errorf("failed to delete %s: %w", s.entitiesName, err)
 	}
 	if taskRef.ExtId == nil {

--- a/converged/v4/recovery_plans_test.go
+++ b/converged/v4/recovery_plans_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/nutanix-cloud-native/prism-go-client/converged"
 	"github.com/nutanix-cloud-native/prism-go-client/internal/testhelpers"
+	v4prismGoClient "github.com/nutanix-cloud-native/prism-go-client/v4"
 
 	dpModels "github.com/nutanix/ntnx-api-golang-clients/datapolicies-go-client/v4/models/datapolicies/v4/config"
 )
@@ -157,39 +158,32 @@ func TestRecoveryPlansService_ErrorHandling(t *testing.T) {
 
 // TestRecoveryPlansService_UnsupportedODataOptions tests that apply and expand options are rejected.
 func TestRecoveryPlansService_UnsupportedODataOptions(t *testing.T) {
-	creds := testhelpers.CredentialsFromEnvironment(t)
-	if strings.Contains(creds.Endpoint, prismEndpointDummyValue) {
-		t.Skip("Skipping integration test: NUTANIX_ENDPOINT not set")
-	}
-
-	client, err := NewClient(creds)
-	require.NoError(t, err)
-	require.NotNil(t, client)
-
+	service := NewRecoveryPlansService(&v4prismGoClient.Client{})
+	require.NotNil(t, service)
 	ctx := context.Background()
 
 	t.Run("List_WithExpand", func(t *testing.T) {
-		_, err := client.DataPolicies.RecoveryPlans.List(ctx, converged.WithExpand("config"))
+		_, err := service.List(ctx, converged.WithExpand("config"))
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "apply and expand options are not supported for listing")
 		assert.Contains(t, err.Error(), "recovery plan")
 	})
 
 	t.Run("List_WithApply", func(t *testing.T) {
-		_, err := client.DataPolicies.RecoveryPlans.List(ctx, converged.WithApply("groupby((extId))"))
+		_, err := service.List(ctx, converged.WithApply("groupby((extId))"))
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "apply and expand options are not supported for listing")
 		assert.Contains(t, err.Error(), "recovery plan")
 	})
 
 	t.Run("List_WithExpandAndLimit", func(t *testing.T) {
-		_, err := client.DataPolicies.RecoveryPlans.List(ctx, converged.WithExpand("config"), converged.WithLimit(5))
+		_, err := service.List(ctx, converged.WithExpand("config"), converged.WithLimit(5))
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "apply and expand options are not supported for listing")
 	})
 
 	t.Run("NewIterator_WithExpand", func(t *testing.T) {
-		iter := client.DataPolicies.RecoveryPlans.NewIterator(ctx, converged.WithExpand("config"))
+		iter := service.NewIterator(ctx, converged.WithExpand("config"))
 		require.NotNil(t, iter)
 
 		var gotError error
@@ -202,7 +196,7 @@ func TestRecoveryPlansService_UnsupportedODataOptions(t *testing.T) {
 	})
 
 	t.Run("NewIterator_WithApply", func(t *testing.T) {
-		iter := client.DataPolicies.RecoveryPlans.NewIterator(ctx, converged.WithApply("groupby((extId))"))
+		iter := service.NewIterator(ctx, converged.WithApply("groupby((extId))"))
 		require.NotNil(t, iter)
 
 		var gotError error


### PR DESCRIPTION
Summary

- Fix DeleteAsync for ProtectionPoliciesService and RecoveryPlansService to fetch the entity's ETag via GetEntityAndEtag before issuing the delete call, ensuring the If-Match header is sent as required by the API.

- Change CallAPI type parameter from *dpPrism.TaskReference (pointer) to dpPrism.TaskReference (value) across CreateAsync, UpdateAsync, and DeleteAsync for both services, removing the now-unnecessary || taskRef == nil nil-pointer checks.

- Convert UnsupportedODataOptions tests from integration tests (requiring a live Nutanix endpoint) to pure unit tests by constructing the service with an empty v4prismGoClient.Client{}, since OData parameter validation is entirely local.