### PR TITLE
feat(converged/v4): add WithExtraHeaders Upload option

### DIFF
--- a/converged/images.go
+++ b/converged/images.go
@@ -1,6 +1,9 @@
 package converged
 
-import "context"
+import (
+	"context"
+	"net/http"
+)
 
 // Images defines the interface for Prism Central images.
 type Images[Image, FileDetail any] interface {
@@ -19,6 +22,45 @@ type Images[Image, FileDetail any] interface {
 	// GetFile downloads the image file for the given UUID.
 	GetFile(ctx context.Context, uuid string) (*FileDetail, error)
 
-	// Upload uploads the image file to the given UUID.
-	Upload(ctx context.Context, uuid, filepath string) error
+	// Upload uploads the image file to the given UUID. Optional UploadOptions
+	// configure the upload — see WithExtraHeaders. Calling Upload with no
+	// options preserves the pre-options behaviour exactly.
+	Upload(ctx context.Context, uuid, filepath string, opts ...UploadOption) error
+}
+
+// UploadOptions holds optional configuration for an Upload call.
+type UploadOptions struct {
+	// ExtraHeaders are merged onto every HTTP request the Objects Lite
+	// upload client makes. Nil or empty means no extra headers.
+	ExtraHeaders http.Header
+}
+
+// UploadOption configures an Upload call.
+type UploadOption func(*UploadOptions)
+
+// WithExtraHeaders adds HTTP headers to every request the Objects Lite S3
+// client makes during an Upload. This is intended for deployments where Prism
+// Central sits behind a service-token gateway (e.g. Cloudflare Access) that
+// requires extra credential headers on every request, including the S3
+// PutObject — which the AWS SDK would otherwise not carry.
+//
+// Headers are applied by an http.RoundTripper wrapper after the AWS SDK
+// signs the request, so they do not invalidate the AWS V4 signature. If a
+// header is set both here and by the AWS SDK, the value supplied here wins.
+//
+// Calling WithExtraHeaders with a nil or empty map is a no-op.
+func WithExtraHeaders(h http.Header) UploadOption {
+	return func(o *UploadOptions) {
+		if len(h) == 0 {
+			return
+		}
+		if o.ExtraHeaders == nil {
+			o.ExtraHeaders = make(http.Header, len(h))
+		}
+		for k, vs := range h {
+			for _, v := range vs {
+				o.ExtraHeaders.Add(k, v)
+			}
+		}
+	}
 }

--- a/converged/images.go
+++ b/converged/images.go
@@ -48,6 +48,9 @@ type UploadOption func(*UploadOptions)
 // signs the request, so they do not invalidate the AWS V4 signature. If a
 // header is set both here and by the AWS SDK, the value supplied here wins.
 //
+// If called multiple times, values are merged; duplicate keys accumulate
+// across calls.
+//
 // Calling WithExtraHeaders with a nil or empty map is a no-op.
 func WithExtraHeaders(h http.Header) UploadOption {
 	return func(o *UploadOptions) {

--- a/converged/v4/images.go
+++ b/converged/v4/images.go
@@ -32,6 +32,27 @@ const (
 	defaultAWSRegion = "us-east-1"
 )
 
+// headerInjectingTransport wraps an http.RoundTripper to set a fixed set of
+// headers on every outgoing request. Used so that the AWS HTTP client's S3
+// PutObject requests carry the same gateway credentials as the rest of the
+// Prism client.
+type headerInjectingTransport struct {
+	base    http.RoundTripper
+	headers http.Header
+}
+
+func (t *headerInjectingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Clone before mutating: per the RoundTripper contract, RoundTrip must
+	// not modify the request the caller passed in.
+	clone := req.Clone(req.Context())
+	for k, vs := range t.headers {
+		for _, v := range vs {
+			clone.Header.Set(k, v)
+		}
+	}
+	return t.base.RoundTrip(clone)
+}
+
 // ImagesService provides implementation for all Images interface methods.
 type ImagesService struct {
 	client       *v4prismGoClient.Client
@@ -166,9 +187,18 @@ func (s *ImagesService) GetFile(ctx context.Context, uuid string) (*imageModels.
 }
 
 // Upload uploads the image file to the given UUID.
-func (s *ImagesService) Upload(ctx context.Context, uuid, filepath string) error {
+//
+// Optional UploadOptions configure the upload — see converged.WithExtraHeaders
+// for the only currently supported option. Calling Upload with no options
+// preserves the pre-options behaviour exactly.
+func (s *ImagesService) Upload(ctx context.Context, uuid, filepath string, opts ...converged.UploadOption) error {
 	if s.client == nil {
 		return errors.New("client is not initialized")
+	}
+
+	uo := &converged.UploadOptions{}
+	for _, opt := range opts {
+		opt(uo)
 	}
 
 	file, err := os.Open(filepath)
@@ -177,7 +207,7 @@ func (s *ImagesService) Upload(ctx context.Context, uuid, filepath string) error
 	}
 	defer func() { _ = file.Close() }()
 
-	if err := s.uploadToObjects(ctx, uuid, file); err != nil {
+	if err := s.uploadToObjects(ctx, uuid, file, uo); err != nil {
 		return err
 	}
 
@@ -194,8 +224,8 @@ func (s *ImagesService) Upload(ctx context.Context, uuid, filepath string) error
 }
 
 // uploadToObjects uploads a file to Objects Lite S3 storage
-func (s *ImagesService) uploadToObjects(ctx context.Context, uuid string, file *os.File) error {
-	awsConfig, endpoint, err := s.awsConfig(ctx)
+func (s *ImagesService) uploadToObjects(ctx context.Context, uuid string, file *os.File, uo *converged.UploadOptions) error {
+	awsConfig, endpoint, err := s.awsConfig(ctx, uo)
 	if err != nil {
 		return err
 	}
@@ -240,7 +270,7 @@ func (s *ImagesService) imageFromObjectsLite(objectKey, sourcePath string) (*ima
 	return image, nil
 }
 
-func (s *ImagesService) awsConfig(_ context.Context) (aws.Config, string, error) {
+func (s *ImagesService) awsConfig(_ context.Context, uo *converged.UploadOptions) (aws.Config, string, error) {
 	apiClient := s.client.ImagesApiInstance.ApiClient
 
 	// Objects Lite S3 endpoint
@@ -261,12 +291,21 @@ func (s *ImagesService) awsConfig(_ context.Context) (aws.Config, string, error)
 		Credentials: credentials.NewStaticCredentialsProvider(encoded, encoded, ""),
 	}
 
-	if !apiClient.VerifySSL {
-		awsCfg.HTTPClient = &http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
-			},
+	// Build a custom HTTP client only when needed: either to skip TLS
+	// verification, or to inject extra headers supplied by the caller.
+	// When neither applies, the AWS SDK's default client is used — preserving
+	// pre-options behaviour exactly.
+	if !apiClient.VerifySSL || (uo != nil && len(uo.ExtraHeaders) > 0) {
+		var transport http.RoundTripper = &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: !apiClient.VerifySSL}, //nolint:gosec
 		}
+		if uo != nil && len(uo.ExtraHeaders) > 0 {
+			transport = &headerInjectingTransport{
+				base:    transport,
+				headers: uo.ExtraHeaders,
+			}
+		}
+		awsCfg.HTTPClient = &http.Client{Transport: transport}
 	}
 
 	return awsCfg, endpoint, nil

--- a/converged/v4/images.go
+++ b/converged/v4/images.go
@@ -46,9 +46,7 @@ func (t *headerInjectingTransport) RoundTrip(req *http.Request) (*http.Response,
 	// not modify the request the caller passed in.
 	clone := req.Clone(req.Context())
 	for k, vs := range t.headers {
-		for _, v := range vs {
-			clone.Header.Set(k, v)
-		}
+		clone.Header[k] = vs
 	}
 	return t.base.RoundTrip(clone)
 }

--- a/converged/v4/images_test.go
+++ b/converged/v4/images_test.go
@@ -14,6 +14,8 @@ package v4
 
 import (
 	"context"
+	"errors"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -90,6 +92,15 @@ func TestImagesService_ErrorHandling(t *testing.T) {
 
 	t.Run("Upload_NilClient", func(t *testing.T) {
 		err := service.Upload(ctx, "test-id", "/path/to/file")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "client is not initialized")
+	})
+
+	t.Run("Upload_NilClient_WithExtraHeaders", func(t *testing.T) {
+		// The option path must not bypass the nil-client guard.
+		err := service.Upload(ctx, "test-id", "/path/to/file",
+			converged.WithExtraHeaders(http.Header{"X-Foo": []string{"bar"}}),
+		)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "client is not initialized")
 	})
@@ -339,7 +350,7 @@ func TestDefaultAWSRegion(t *testing.T) {
 		service := &ImagesService{
 			client: newFakeV4Client("pc.example.com", 9440, "admin", "password", false),
 		}
-		awsCfg, endpoint, err := service.awsConfig(context.Background())
+		awsCfg, endpoint, err := service.awsConfig(context.Background(), nil)
 		require.NoError(t, err)
 
 		assert.Equal(t, defaultAWSRegion, awsCfg.Region,
@@ -355,7 +366,7 @@ func TestDefaultAWSRegion(t *testing.T) {
 		service := &ImagesService{
 			client: newFakeV4Client("pc.example.com", 9440, "admin", "password", true),
 		}
-		awsCfg, _, err := service.awsConfig(context.Background())
+		awsCfg, _, err := service.awsConfig(context.Background(), nil)
 		require.NoError(t, err)
 		assert.NotNil(t, awsCfg.HTTPClient, "HTTPClient should be set when VerifySSL is false")
 	})
@@ -364,7 +375,7 @@ func TestDefaultAWSRegion(t *testing.T) {
 		service := &ImagesService{
 			client: newFakeV4Client("pc.example.com", 9440, "", "", false),
 		}
-		_, _, err := service.awsConfig(context.Background())
+		_, _, err := service.awsConfig(context.Background(), nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "username and password are required")
 	})
@@ -421,5 +432,158 @@ func TestConstants(t *testing.T) {
 
 	t.Run("DefaultAWSRegion", func(t *testing.T) {
 		assert.Equal(t, "us-east-1", defaultAWSRegion)
+	})
+}
+
+// TestWithExtraHeaders verifies the option accumulates headers into the
+// UploadOptions struct and that nil/empty input is a no-op.
+func TestWithExtraHeaders(t *testing.T) {
+	t.Run("NilInput", func(t *testing.T) {
+		opts := &converged.UploadOptions{}
+		converged.WithExtraHeaders(nil)(opts)
+		assert.Nil(t, opts.ExtraHeaders)
+	})
+
+	t.Run("EmptyInput", func(t *testing.T) {
+		opts := &converged.UploadOptions{}
+		converged.WithExtraHeaders(http.Header{})(opts)
+		assert.Nil(t, opts.ExtraHeaders)
+	})
+
+	t.Run("SingleHeader", func(t *testing.T) {
+		opts := &converged.UploadOptions{}
+		converged.WithExtraHeaders(http.Header{"X-Foo": []string{"bar"}})(opts)
+		assert.Equal(t, "bar", opts.ExtraHeaders.Get("X-Foo"))
+	})
+
+	t.Run("MultipleHeaders", func(t *testing.T) {
+		opts := &converged.UploadOptions{}
+		converged.WithExtraHeaders(http.Header{
+			"X-Foo": []string{"foo"},
+			"X-Bar": []string{"bar"},
+		})(opts)
+		assert.Equal(t, "foo", opts.ExtraHeaders.Get("X-Foo"))
+		assert.Equal(t, "bar", opts.ExtraHeaders.Get("X-Bar"))
+	})
+
+	t.Run("MultipleApplicationsAccumulate", func(t *testing.T) {
+		opts := &converged.UploadOptions{}
+		converged.WithExtraHeaders(http.Header{"X-Foo": []string{"foo"}})(opts)
+		converged.WithExtraHeaders(http.Header{"X-Bar": []string{"bar"}})(opts)
+		assert.Equal(t, "foo", opts.ExtraHeaders.Get("X-Foo"))
+		assert.Equal(t, "bar", opts.ExtraHeaders.Get("X-Bar"))
+	})
+}
+
+// recordingRoundTripper captures the request it sees and returns a fixed
+// response. Used to assert that headerInjectingTransport mutates the request
+// it forwards but NOT the request its caller handed in.
+type recordingRoundTripper struct {
+	seen *http.Request
+}
+
+func (r *recordingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	r.seen = req
+	return &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{},
+		Body:       http.NoBody,
+		Request:    req,
+	}, nil
+}
+
+// errRoundTripper always returns an error, used to assert error propagation.
+type errRoundTripper struct{ err error }
+
+func (e *errRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, e.err
+}
+
+func TestHeaderInjectingTransport(t *testing.T) {
+	t.Run("InjectsHeaders", func(t *testing.T) {
+		rec := &recordingRoundTripper{}
+		tr := &headerInjectingTransport{
+			base: rec,
+			headers: http.Header{
+				"X-Auth":     []string{"token-123"},
+				"X-Tenant":   []string{"acme"},
+				"X-Multiple": []string{"first", "second"},
+			},
+		}
+
+		req, err := http.NewRequest(http.MethodPut, "https://example.test/path", nil)
+		require.NoError(t, err)
+
+		_, err = tr.RoundTrip(req)
+		require.NoError(t, err)
+		require.NotNil(t, rec.seen)
+
+		assert.Equal(t, "token-123", rec.seen.Header.Get("X-Auth"))
+		assert.Equal(t, "acme", rec.seen.Header.Get("X-Tenant"))
+		// Set semantics: last write wins, only the final value survives.
+		assert.Equal(t, []string{"second"}, rec.seen.Header.Values("X-Multiple"))
+	})
+
+	t.Run("OverwritesExistingHeader", func(t *testing.T) {
+		rec := &recordingRoundTripper{}
+		tr := &headerInjectingTransport{
+			base:    rec,
+			headers: http.Header{"X-Auth": []string{"injected"}},
+		}
+
+		req, err := http.NewRequest(http.MethodPut, "https://example.test/path", nil)
+		require.NoError(t, err)
+		req.Header.Set("X-Auth", "original")
+
+		_, err = tr.RoundTrip(req)
+		require.NoError(t, err)
+		// Caller's request must be unchanged (RoundTripper contract).
+		assert.Equal(t, "original", req.Header.Get("X-Auth"))
+		// Forwarded request carries the injected value.
+		assert.Equal(t, "injected", rec.seen.Header.Get("X-Auth"))
+	})
+
+	t.Run("DoesNotMutateCallerRequest", func(t *testing.T) {
+		rec := &recordingRoundTripper{}
+		tr := &headerInjectingTransport{
+			base:    rec,
+			headers: http.Header{"X-Injected": []string{"yes"}},
+		}
+
+		req, err := http.NewRequest(http.MethodPut, "https://example.test/path", nil)
+		require.NoError(t, err)
+
+		_, err = tr.RoundTrip(req)
+		require.NoError(t, err)
+		// The caller's request must not have gained the injected header.
+		assert.Empty(t, req.Header.Get("X-Injected"))
+		assert.Equal(t, "yes", rec.seen.Header.Get("X-Injected"))
+	})
+
+	t.Run("EmptyHeadersIsPassThrough", func(t *testing.T) {
+		rec := &recordingRoundTripper{}
+		tr := &headerInjectingTransport{base: rec, headers: http.Header{}}
+
+		req, err := http.NewRequest(http.MethodPut, "https://example.test/path", nil)
+		require.NoError(t, err)
+		req.Header.Set("X-Existing", "kept")
+
+		_, err = tr.RoundTrip(req)
+		require.NoError(t, err)
+		assert.Equal(t, "kept", rec.seen.Header.Get("X-Existing"))
+	})
+
+	t.Run("PropagatesBaseError", func(t *testing.T) {
+		baseErr := errors.New("network down")
+		tr := &headerInjectingTransport{
+			base:    &errRoundTripper{err: baseErr},
+			headers: http.Header{"X-Auth": []string{"t"}},
+		}
+
+		req, err := http.NewRequest(http.MethodPut, "https://example.test/path", nil)
+		require.NoError(t, err)
+
+		_, err = tr.RoundTrip(req)
+		assert.ErrorIs(t, err, baseErr)
 	})
 }

--- a/converged/v4/images_test.go
+++ b/converged/v4/images_test.go
@@ -520,8 +520,7 @@ func TestHeaderInjectingTransport(t *testing.T) {
 
 		assert.Equal(t, "token-123", rec.seen.Header.Get("X-Auth"))
 		assert.Equal(t, "acme", rec.seen.Header.Get("X-Tenant"))
-		// Set semantics: last write wins, only the final value survives.
-		assert.Equal(t, []string{"second"}, rec.seen.Header.Values("X-Multiple"))
+		assert.Equal(t, []string{"first", "second"}, rec.seen.Header.Values("X-Multiple"))
 	})
 
 	t.Run("OverwritesExistingHeader", func(t *testing.T) {


### PR DESCRIPTION
`ImagesService.Upload` builds the AWS HTTP client internally inside
`awsConfig()` with no way for callers to inject custom HTTP headers. This
blocks use of `Upload` when Prism Central sits behind a service-token gateway
(e.g. Cloudflare Access) that requires extra credential headers on every
request — including the S3 `PutObject` the upload makes against PC's Objects
Lite endpoint, which the AWS SDK would otherwise not carry.

- Adds `converged.UploadOption` and `converged.WithExtraHeaders(http.Header)`.
- `ImagesService.Upload` gains variadic `...UploadOption`. Existing callers
  compile unchanged; calling `Upload` with no options preserves the
  pre-options behaviour exactly (AWS SDK default HTTP client).
- When extra headers are supplied, the AWS HTTP client's transport is wrapped
  by an `http.RoundTripper` that injects them *after* AWS V4 signing, so the
  signature is not invalidated.
- Composes orthogonally with the existing `!VerifySSL` path: TLS skip-verify
  is configured on the inner `*http.Transport`; header injection wraps that
  transport.
- Unit tests cover the option accumulator, the round-tripper (including
  clone-before-mutate per the `RoundTripper` contract), and the nil-client
  guard with the option set.

Downstream consumer: [packer-plugin-nutanix#358](https://github.com/nutanix-cloud-native/packer-plugin-nutanix/pull/358),
which currently reimplements `Upload` / `uploadToObjects` / `awsConfig`
locally to inject headers. Once this lands, that reimplementation is deleted
and Packer calls `Upload(ctx, uuid, path, converged.WithExtraHeaders(h))`.

Considered but not included: a `WithHTTPClient(*http.Client)` option as a
more general escape hatch. Held off to keep the surface minimal — happy to
expand if you prefer the broader hook.
