### PR TITLE
fix: avoid leaking host AWS config into Objects Lite S3 uploads

### DIFF
--- a/converged/v4/images.go
+++ b/converged/v4/images.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -241,43 +240,36 @@ func (s *ImagesService) imageFromObjectsLite(objectKey, sourcePath string) (*ima
 	return image, nil
 }
 
-func (s *ImagesService) awsConfig(ctx context.Context) (aws.Config, string, error) {
+func (s *ImagesService) awsConfig(_ context.Context) (aws.Config, string, error) {
 	apiClient := s.client.ImagesApiInstance.ApiClient
 
 	// Objects Lite S3 endpoint
 	endpoint := fmt.Sprintf("https://%s:%d/api/prism/v4.0/objects/", apiClient.Host, apiClient.Port)
 
-	// Use ApiClient's username and password
 	username := strings.TrimSpace(apiClient.Username)
 	password := strings.TrimSpace(apiClient.Password)
 	if username == "" || password == "" {
 		return aws.Config{}, "", fmt.Errorf("username and password are required for Objects Lite auth")
 	}
 
-	// AWS region from environment variable, defaults to us-east-1
-	region := os.Getenv("AWS_REGION")
-	if region == "" {
-		region = defaultAWSRegion
-	}
-
 	encoded := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", username, password)))
-	loadOptions := []func(*config.LoadOptions) error{
-		config.WithRegion(region),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(encoded, encoded, "")),
-	}
-	if !apiClient.VerifySSL {
-		loadOptions = append(loadOptions, config.WithHTTPClient(&http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-			},
-		}))
+
+	// Construct config directly — do not use config.LoadDefaultConfig which
+	// leaks host AWS env vars/config and breaks Objects Lite (always us-east-1).
+	awsCfg := aws.Config{
+		Region:      defaultAWSRegion,
+		Credentials: credentials.NewStaticCredentialsProvider(encoded, encoded, ""),
 	}
 
-	awsConfig, err := config.LoadDefaultConfig(ctx, loadOptions...)
-	if err != nil {
-		return aws.Config{}, "", fmt.Errorf("failed to load AWS config: %w", err)
+	if !apiClient.VerifySSL {
+		awsCfg.HTTPClient = &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+			},
+		}
 	}
-	return awsConfig, endpoint, nil
+
+	return awsCfg, endpoint, nil
 }
 
 // CreateAsync creates a new image asynchronously.

--- a/converged/v4/images_test.go
+++ b/converged/v4/images_test.go
@@ -24,9 +24,27 @@ import (
 
 	"github.com/nutanix-cloud-native/prism-go-client/converged"
 	"github.com/nutanix-cloud-native/prism-go-client/internal/testhelpers"
+	v4prismGoClient "github.com/nutanix-cloud-native/prism-go-client/v4"
 
+	vmClient "github.com/nutanix/ntnx-api-golang-clients/vmm-go-client/v4/client"
+	vmApi "github.com/nutanix/ntnx-api-golang-clients/vmm-go-client/v4/api"
 	imageModels "github.com/nutanix/ntnx-api-golang-clients/vmm-go-client/v4/models/vmm/v4/content"
 )
+
+// newFakeV4Client creates a minimal V4 client with the given parameters for unit testing.
+// The insecureSkipVerify parameter controls whether VerifySSL is false (i.e., insecure=true means VerifySSL=false).
+func newFakeV4Client(host string, port int, username, password string, insecureSkipVerify bool) *v4prismGoClient.Client {
+	apiClientInstance := vmClient.NewApiClient()
+	apiClientInstance.Host = host
+	apiClientInstance.Port = port
+	apiClientInstance.Username = username
+	apiClientInstance.Password = password
+	apiClientInstance.VerifySSL = !insecureSkipVerify
+
+	return &v4prismGoClient.Client{
+		ImagesApiInstance: vmApi.NewImagesApi(apiClientInstance),
+	}
+}
 
 // TestImagesService_ErrorHandling tests error handling for nil client
 func TestImagesService_ErrorHandling(t *testing.T) {
@@ -311,17 +329,44 @@ func TestImageFromObjectsLite(t *testing.T) {
 // TestDefaultAWSRegion tests the AWS region default behavior
 func TestDefaultAWSRegion(t *testing.T) {
 	t.Run("DefaultRegion", func(t *testing.T) {
-		// Verify the default constant is set correctly
 		assert.Equal(t, "us-east-1", defaultAWSRegion)
 	})
 
-	t.Run("EnvVarOverride", func(t *testing.T) {
-		// Test that AWS_REGION env var is read
-		// Using t.Setenv which automatically cleans up after test
+	t.Run("IgnoresAWSRegionEnvVar", func(t *testing.T) {
 		t.Setenv("AWS_REGION", "eu-west-1")
+		t.Setenv("AWS_DEFAULT_REGION", "ap-southeast-1")
 
-		region := os.Getenv("AWS_REGION")
-		assert.Equal(t, "eu-west-1", region)
+		service := &ImagesService{
+			client: newFakeV4Client("pc.example.com", 9440, "admin", "password", false),
+		}
+		awsCfg, endpoint, err := service.awsConfig(context.Background())
+		require.NoError(t, err)
+
+		assert.Equal(t, defaultAWSRegion, awsCfg.Region,
+			"awsConfig must always use us-east-1 regardless of AWS_REGION env var")
+		assert.Equal(t, "https://pc.example.com:9440/api/prism/v4.0/objects/", endpoint)
+
+		creds, err := awsCfg.Credentials.Retrieve(context.Background())
+		require.NoError(t, err)
+		assert.NotEmpty(t, creds.AccessKeyID)
+	})
+
+	t.Run("InsecureSSL", func(t *testing.T) {
+		service := &ImagesService{
+			client: newFakeV4Client("pc.example.com", 9440, "admin", "password", true),
+		}
+		awsCfg, _, err := service.awsConfig(context.Background())
+		require.NoError(t, err)
+		assert.NotNil(t, awsCfg.HTTPClient, "HTTPClient should be set when VerifySSL is false")
+	})
+
+	t.Run("MissingCredentials", func(t *testing.T) {
+		service := &ImagesService{
+			client: newFakeV4Client("pc.example.com", 9440, "", "", false),
+		}
+		_, _, err := service.awsConfig(context.Background())
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "username and password are required")
 	})
 }
 


### PR DESCRIPTION
## Problem

Since packer-plugin-nutanix v1.1.5 switched to the v4 API, image uploads go through
Nutanix Objects Lite (an internal S3-compatible endpoint). The `awsConfig()` function
used `config.LoadDefaultConfig()` from the AWS SDK, which loads the full default
configuration chain — environment variables, `~/.aws/config`, EC2 instance metadata, etc.

Objects Lite always expects region `us-east-1`. When the host environment had
`AWS_REGION` set to anything else (common in CI/CD pipelines and Docker containers),
the S3 PutObject request was signed with the wrong region, causing:


IllegalLocationConstraintException: Attempting to access a bucket from a different region than where the bucket exists.


## Fix

Replace `config.LoadDefaultConfig()` with a directly constructed `aws.Config` that
hardcodes `us-east-1` and uses static credentials. This ensures external AWS
configuration never leaks into Objects Lite requests.

## Testing

- Unit test added (`TestDefaultAWSRegion/IgnoresAWSRegionEnvVar`) that sets
  `AWS_REGION=eu-west-1` and verifies `awsConfig()` still returns `us-east-1`.
- End-to-end validated: full packer build with `cd_files` ISO upload succeeds
  with `AWS_REGION=eu-west-1` in the environment. Without the fix, the same
  build fails immediately with `IllegalLocationConstraintException`.

[Fixes: https://github.com/nutanix-cloud-native/packer-plugin-nutanix/issues/370](https://github.com/nutanix-cloud-native/packer-plugin-nutanix/issues/370)