### PR TITLE
fix: stop converged v4 list-all pagination on empty page

### DIFF
--- a/converged/v4/utils.go
+++ b/converged/v4/utils.go
@@ -340,6 +340,16 @@ func GenericListEntities[R APIResponse, T any](apiCall func(reqParams *V4ODataPa
 			if err != nil {
 				return nil, fmt.Errorf("failed to list all %s on page %d: %w", entitiesName, *reqParams.Page, err)
 			}
+			// Guard against an unbounded loop. totalCount is a snapshot of
+			// metadata.TotalAvailableResults from the first page, while the
+			// underlying data set can shrink between requests (entities being
+			// deleted) and the count and page data are only eventually
+			// consistent. If we ever get a page with no items, the server has
+			// nothing more to return, so stop instead of paging forever past
+			// the last page of data.
+			if len(moreItems) == 0 {
+				break
+			}
 			result = append(result, moreItems...)
 		}
 	}

--- a/converged/v4/utils_test.go
+++ b/converged/v4/utils_test.go
@@ -1,0 +1,100 @@
+package v4
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
+)
+
+// fakeListMetadata mimics the generated *ApiResponseMetadata shape that
+// GetMetadataTotalResults reflects over (it only needs a TotalAvailableResults
+// *int field).
+type fakeListMetadata struct {
+	TotalAvailableResults *int
+}
+
+// fakeListResponse mimics a generated *List<Entity>ApiResponse: it exposes a
+// Metadata field for reflection and a GetData accessor for the page payload.
+type fakeListResponse struct {
+	Metadata *fakeListMetadata
+	data     []string
+}
+
+func (r *fakeListResponse) GetData() any {
+	if r.data == nil {
+		return nil
+	}
+	return r.data
+}
+
+// TestGenericListEntities_StopsOnEmptyPage ensures the list-all pagination loop
+// terminates when a page returns no items, even though the cumulative number of
+// collected items never reaches the totalCount snapshot taken from the first
+// page. This reproduces the runaway pagination observed against a PC whose
+// image set shrank (or whose TotalAvailableResults was inconsistent with the
+// page data) during a list, which previously caused the loop to request pages
+// far beyond the last page of real data.
+func TestGenericListEntities_StopsOnEmptyPage(t *testing.T) {
+	const total = 10 // reported by the first page's metadata
+	// Only pages 0 and 1 carry data (6 items total); every later page is empty,
+	// so len(result) never reaches total. Without the empty-page guard the loop
+	// would page forever.
+	pageData := map[int][]string{
+		0: {"a", "b", "c"},
+		1: {"d", "e", "f"},
+	}
+
+	const maxPagesBeforeFailing = 100
+	callCount := 0
+
+	apiCall := func(reqParams *V4ODataParams) (*fakeListResponse, error) {
+		callCount++
+		require.LessOrEqual(t, callCount, maxPagesBeforeFailing,
+			"GenericListEntities paged past the available data; the empty-page guard is not working")
+
+		page := 0
+		if reqParams.Page != nil {
+			page = *reqParams.Page
+		}
+		return &fakeListResponse{
+			Metadata: &fakeListMetadata{TotalAvailableResults: ptr.To(total)},
+			data:     pageData[page],
+		}, nil
+	}
+
+	result, err := GenericListEntities[*fakeListResponse, string](apiCall, nil, "fake")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a", "b", "c", "d", "e", "f"}, result)
+}
+
+// TestGenericListEntities_PagesUntilTotalCount ensures the loop still walks
+// every page until totalCount is reached when the data set is consistent.
+func TestGenericListEntities_PagesUntilTotalCount(t *testing.T) {
+	const total = 5
+	pageData := map[int][]string{
+		0: {"a", "b"},
+		1: {"c", "d"},
+		2: {"e"},
+	}
+
+	callCount := 0
+	apiCall := func(reqParams *V4ODataParams) (*fakeListResponse, error) {
+		callCount++
+		page := 0
+		if reqParams.Page != nil {
+			page = *reqParams.Page
+		}
+		return &fakeListResponse{
+			Metadata: &fakeListMetadata{TotalAvailableResults: ptr.To(total)},
+			data:     pageData[page],
+		}, nil
+	}
+
+	result, err := GenericListEntities[*fakeListResponse, string](apiCall, nil, "fake")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a", "b", "c", "d", "e"}, result)
+	// Pages 0, 1 and 2 are fetched; once len(result) == total the loop stops.
+	assert.Equal(t, 3, callCount)
+}


### PR DESCRIPTION
## Summary

`GenericListEntities` (the list-all code path used by `Images.List(ctx)`, `VMs.List`, etc. when no `Page`/`Limit` is supplied) paginates with:

```go
for len(result) < totalCount {
    page++
    ...
    result = append(result, moreItems...)
}
```

`totalCount` is a one-time snapshot of `metadata.TotalAvailableResults` taken from the **first** page. The loop had **no guard for a page that returns zero items**, so its only exit condition was `len(result) >= totalCount`. Whenever the cumulative number of collected items never reaches that snapshot, the loop increments `$page` forever.

This happens in practice when:
- the underlying entity set **shrinks mid-list** (e.g. entities being deleted concurrently — observed during cluster teardown), or
- `TotalAvailableResults` and the page data are only **eventually consistent** (IDF), so the reported total exceeds what pagination can actually return.

### Observed impact

While resolving an image via lookup (`Images.List(ctx)` with no filter), CAPX was seen requesting `GET /api/vmm/v4.x/content/images?$page=3792` and beyond against a Prism Central that only had ~3363 images — i.e. paging thousands of pages past the last page of real data, hammering PC and stalling reconciliation until the context deadline.

## Fix

Break out of the loop when a page returns no items, mirroring the existing `len(items) == 0` guard already present in the `NewIterator` implementation in `structs.go`.

## Test plan

- [x] Added `TestGenericListEntities_StopsOnEmptyPage` — reproduces the runaway loop (cumulative items never reach `totalCount`) and asserts it terminates on the first empty page. Includes a call-count cap so a regression fails fast instead of hanging.
- [x] Added `TestGenericListEntities_PagesUntilTotalCount` — verifies normal multi-page pagination still walks every page until `totalCount` is reached.
- [x] `go test ./converged/v4/ -run TestGenericListEntities -v` passes
- [x] `go vet ./converged/v4/` and `go build ./converged/...` clean

Made with [Cursor](https://cursor.com)