### PR TITLE
fix: refresh totalCount per page in converged v4 list-all pagination

### DIFF
--- a/converged/v4/utils.go
+++ b/converged/v4/utils.go
@@ -336,21 +336,24 @@ func GenericListEntities[R APIResponse, T any](apiCall func(reqParams *V4ODataPa
 		for len(result) < totalCount {
 			page++
 			reqParams.Page = ptr.To(page)
-			moreItems, _, err := CallListAPI[R, T](apiCall(reqParams))
+			moreItems, latestTotalCount, err := CallListAPI[R, T](apiCall(reqParams))
 			if err != nil {
 				return nil, fmt.Errorf("failed to list all %s on page %d: %w", entitiesName, *reqParams.Page, err)
 			}
-			// Guard against an unbounded loop. totalCount is a snapshot of
-			// metadata.TotalAvailableResults from the first page, while the
-			// underlying data set can shrink between requests (entities being
-			// deleted) and the count and page data are only eventually
-			// consistent. If we ever get a page with no items, the server has
-			// nothing more to return, so stop instead of paging forever past
+			// Guard against an unbounded loop. metadata.TotalAvailableResults
+			// and the page data are only eventually consistent, so the data set
+			// can shrink between requests (entities being deleted) and the count
+			// can lag behind it. If we ever get a page with no items, the server
+			// has nothing more to return, so stop instead of paging forever past
 			// the last page of data.
 			if len(moreItems) == 0 {
 				break
 			}
 			result = append(result, moreItems...)
+			// Re-read the total from each page so that entities added while we
+			// paginate are still collected, rather than stopping at the (now
+			// stale) total observed on the first page.
+			totalCount = latestTotalCount
 		}
 	}
 

--- a/converged/v4/utils_test.go
+++ b/converged/v4/utils_test.go
@@ -98,3 +98,40 @@ func TestGenericListEntities_PagesUntilTotalCount(t *testing.T) {
 	// Pages 0, 1 and 2 are fetched; once len(result) == total the loop stops.
 	assert.Equal(t, 3, callCount)
 }
+
+// TestGenericListEntities_CollectsItemsAddedWhilePaging ensures that entities
+// added after the first page is fetched are still collected, by re-reading the
+// total from each page instead of trusting the first page's (now stale) total.
+func TestGenericListEntities_CollectsItemsAddedWhilePaging(t *testing.T) {
+	// Page 0 reports a total of 4. While we are still paginating (before len has
+	// caught up to that total) two items are added, and the total reported by
+	// page 1 grows to 6, extending the walk to collect them.
+	pages := []struct {
+		data  []string
+		total int
+	}{
+		{data: []string{"a", "b"}, total: 4}, // first page: total observed as 4
+		{data: []string{"c", "d"}, total: 6}, // two items added; total now 6
+		{data: []string{"e", "f"}, total: 6}, // the added items
+	}
+
+	callCount := 0
+	apiCall := func(reqParams *V4ODataParams) (*fakeListResponse, error) {
+		page := 0
+		if reqParams.Page != nil {
+			page = *reqParams.Page
+		}
+		callCount++
+		require.Less(t, page, len(pages), "paged past the fixtures")
+		return &fakeListResponse{
+			Metadata: &fakeListMetadata{TotalAvailableResults: ptr.To(pages[page].total)},
+			data:     pages[page].data,
+		}, nil
+	}
+
+	result, err := GenericListEntities[*fakeListResponse, string](apiCall, nil, "fake")
+	require.NoError(t, err)
+	// Without refreshing totalCount the loop would have stopped after page 1
+	// (len == 4 == stale total) and dropped "e" and "f".
+	assert.Equal(t, []string{"a", "b", "c", "d", "e", "f"}, result)
+}


### PR DESCRIPTION
## Summary

Follow-up to #357. That PR added an empty-page guard so the list-all loop in `GenericListEntities` can no longer spin forever when the entity set **shrinks** (or `TotalAvailableResults` lags behind it). This PR handles the **opposite** direction.

The loop reads `metadata.TotalAvailableResults` from the **first page** and then uses that frozen value as its termination bound for the whole run (the per-page count was discarded via `_`). Because the count and the page data are only **eventually consistent**, when entities are *added* while we paginate the loop stops at the stale first-page total and silently drops the newly added tail.

Example (server page size 50, page-0 total = 100):
- page0 → 50 (len 50), page1 → 50 (len 100) → `100 < 100` false → exit.
- If items were added mid-list (real total now > 100), they are never fetched.

## Change

Re-read the total returned by **each** page (`totalCount = latestTotalCount`) so additions made while paginating are still collected. The empty-page guard from #357 stays as the definitive end-of-data terminator, so this is safe in both directions:
- **shrink / stale-high count** → empty page → `break`
- **grow** → refreshed total extends the walk until we catch up (or hit an empty page)

## Known limitations (called out intentionally, not addressed here)

- Under *continuous* additions the loop can run until the context deadline — inherent to "list everything from an actively-growing set"; the empty-page guard and ctx cancellation are the backstops.
- Offset/`$page` pagination over a mutating set only appends cleanly with a stable ascending `$orderby`; without one, concurrent inserts/deletes can still cause skips/dupes. Adding a default `$orderby` would change behavior for all `List` callers, so it's deliberately out of scope.

## Test plan

- [x] `TestGenericListEntities_CollectsItemsAddedWhilePaging` — total grows across pages; asserts the added items are collected. Verified it **fails without** the refresh (returns the truncated set) and passes with it.
- [x] `TestGenericListEntities_StopsOnEmptyPage` and `TestGenericListEntities_PagesUntilTotalCount` still pass (shrink/empty-page and normal pagination unaffected).
- [x] `go vet ./converged/v4/` and `go build ./converged/...` clean.

Made with [Cursor](https://cursor.com)