### PR TITLE
feat: add converged templates update apis

### DIFF
--- a/converged/templates.go
+++ b/converged/templates.go
@@ -1,5 +1,7 @@
 package converged
 
+import "context"
+
 // Templates defines the interface for Prism Central templates.
 type Templates[Template any] interface {
 	// Getter is the interface for Get operations.
@@ -10,4 +12,26 @@ type Templates[Template any] interface {
 
 	// Creator is the interface for Create operations.
 	Creator[Template]
+
+	// InitiateGuestUpdate starts a temporary VM for guest OS update.
+	// for a given template UUID.
+	InitiateGuestUpdate(ctx context.Context, templateExtID string, versionID string) (*Template, error)
+
+	// InitiateGuestUpdateAsync is the non-blocking variant of InitiateGuestUpdate.
+	InitiateGuestUpdateAsync(templateExtID string, versionID string) (Operation[Template], error)
+
+	// CompleteGuestUpdate finalizes an in-progress guest OS update.
+	// A new template version is created from the temporary VM state, and
+	// the temporary VM is deleted.
+	CompleteGuestUpdate(ctx context.Context, templateExtID string, versionName string, versionDescription string, isActiveVersion bool) (*Template, error)
+
+	// CompleteGuestUpdateAsync is the non-blocking variant of CompleteGuestUpdate.
+	CompleteGuestUpdateAsync(templateExtID string, versionName string, versionDescription string, isActiveVersion bool) (Operation[Template], error)
+
+	// CancelGuestUpdate aborts an in-progress guest OS update.
+	// The temporary VM is deleted and the pending update status is cleared.
+	CancelGuestUpdate(ctx context.Context, templateExtID string) error
+
+	// CancelGuestUpdateAsync is the non-blocking variant of CancelGuestUpdate.
+	CancelGuestUpdateAsync(templateExtID string) (Operation[NoEntity], error)
 }

--- a/converged/v4/templates.go
+++ b/converged/v4/templates.go
@@ -133,3 +133,152 @@ func (s *TemplatesService) CreateAsync(ctx context.Context, template *templateMo
 		s.Get,
 	), nil
 }
+
+// InitiateGuestUpdate starts a guest OS update for the given template.
+// A temporary VM is created from the active version (or the version specified
+// by versionID if non-empty). The returned Template contains
+// GuestUpdateStatus.DeployedVmReference with the temporary VM ext ID.
+func (s *TemplatesService) InitiateGuestUpdate(ctx context.Context, templateExtID string, versionID string) (*templateModels.Template, error) {
+	if s.client == nil {
+		return nil, errors.New("client is not initialized")
+	}
+	operation, err := s.InitiateGuestUpdateAsync(templateExtID, versionID)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := operation.Wait(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initiate guest update: %w", err)
+	}
+
+	if len(result) == 0 {
+		return nil, fmt.Errorf("initiate guest update completed but no template returned")
+	}
+
+	return result[0], nil
+}
+
+// InitiateGuestUpdateAsync is the non-blocking variant of InitiateGuestUpdate.
+func (s *TemplatesService) InitiateGuestUpdateAsync(templateExtID string, versionID string) (converged.Operation[templateModels.Template], error) {
+	if s.client == nil {
+		return nil, errors.New("client is not initialized")
+	}
+
+	spec := templateModels.NewInitiateGuestUpdateSpec()
+	if versionID != "" {
+		spec.VersionId = &versionID
+	}
+
+	taskRef, err := CallAPI[*templateModels.InitiateGuestUpdateApiResponse, vmmPrismModels.TaskReference](
+		s.client.TemplatesApiInstance.InitiateGuestUpdate(&templateExtID, spec),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initiate guest update: %w", err)
+	}
+
+	if taskRef.ExtId == nil {
+		return nil, fmt.Errorf("task reference ExtId is nil for initiate guest update")
+	}
+
+	return NewOperation(
+		*taskRef.ExtId,
+		s.client,
+		s.Get,
+	), nil
+}
+
+// CompleteGuestUpdate finalizes an in-progress guest OS update on the template.
+// A new version is created from the temporary VM and the temporary VM is deleted.
+func (s *TemplatesService) CompleteGuestUpdate(ctx context.Context, templateExtID string, versionName string, versionDescription string, isActiveVersion bool) (*templateModels.Template, error) {
+	if s.client == nil {
+		return nil, errors.New("client is not initialized")
+	}
+	operation, err := s.CompleteGuestUpdateAsync(templateExtID, versionName, versionDescription, isActiveVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := operation.Wait(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to complete guest update: %w", err)
+	}
+
+	if len(result) == 0 {
+		return nil, fmt.Errorf("complete guest update completed but no template returned")
+	}
+
+	return result[0], nil
+}
+
+// CompleteGuestUpdateAsync is the non-blocking variant of CompleteGuestUpdate.
+func (s *TemplatesService) CompleteGuestUpdateAsync(templateExtID string, versionName string, versionDescription string, isActiveVersion bool) (converged.Operation[templateModels.Template], error) {
+	if s.client == nil {
+		return nil, errors.New("client is not initialized")
+	}
+
+	spec := templateModels.NewCompleteGuestUpdateSpec()
+	spec.VersionName = &versionName
+	spec.VersionDescription = &versionDescription
+	spec.IsActiveVersion = &isActiveVersion
+
+	taskRef, err := CallAPI[*templateModels.CompleteGuestUpdateApiResponse, vmmPrismModels.TaskReference](
+		s.client.TemplatesApiInstance.CompleteGuestUpdate(&templateExtID, spec),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to complete guest update: %w", err)
+	}
+
+	if taskRef.ExtId == nil {
+		return nil, fmt.Errorf("task reference ExtId is nil for complete guest update")
+	}
+
+	return NewOperation(
+		*taskRef.ExtId,
+		s.client,
+		s.Get,
+	), nil
+}
+
+// CancelGuestUpdate aborts an in-progress guest OS update on the template.
+// The temporary VM is deleted and the pending update status is cleared.
+func (s *TemplatesService) CancelGuestUpdate(ctx context.Context, templateExtID string) error {
+	if s.client == nil {
+		return errors.New("client is not initialized")
+	}
+	operation, err := s.CancelGuestUpdateAsync(templateExtID)
+	if err != nil {
+		return err
+	}
+
+	_, err = operation.Wait(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to cancel guest update: %w", err)
+	}
+
+	return nil
+}
+
+// CancelGuestUpdateAsync is the non-blocking variant of CancelGuestUpdate.
+func (s *TemplatesService) CancelGuestUpdateAsync(templateExtID string) (converged.Operation[converged.NoEntity], error) {
+	if s.client == nil {
+		return nil, errors.New("client is not initialized")
+	}
+
+	taskRef, err := CallAPI[*templateModels.CancelGuestUpdateApiResponse, vmmPrismModels.TaskReference](
+		s.client.TemplatesApiInstance.CancelGuestUpdate(&templateExtID),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to cancel guest update: %w", err)
+	}
+
+	if taskRef.ExtId == nil {
+		return nil, fmt.Errorf("task reference ExtId is nil for cancel guest update")
+	}
+
+	return NewOperation(
+		*taskRef.ExtId,
+		s.client,
+		converged.NoEntityGetter,
+	), nil
+}

--- a/converged/v4/templates_test.go
+++ b/converged/v4/templates_test.go
@@ -62,6 +62,42 @@ func TestTemplatesService_ErrorHandling(t *testing.T) {
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "client is not initialized")
 	})
+
+	t.Run("InitiateGuestUpdate_NilClient", func(t *testing.T) {
+		_, err := service.InitiateGuestUpdate(ctx, "test-id", "")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "client is not initialized")
+	})
+
+	t.Run("InitiateGuestUpdateAsync_NilClient", func(t *testing.T) {
+		_, err := service.InitiateGuestUpdateAsync("test-id", "")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "client is not initialized")
+	})
+
+	t.Run("CompleteGuestUpdate_NilClient", func(t *testing.T) {
+		_, err := service.CompleteGuestUpdate(ctx, "test-id", "v2", "desc", true)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "client is not initialized")
+	})
+
+	t.Run("CompleteGuestUpdateAsync_NilClient", func(t *testing.T) {
+		_, err := service.CompleteGuestUpdateAsync("test-id", "v2", "desc", true)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "client is not initialized")
+	})
+
+	t.Run("CancelGuestUpdate_NilClient", func(t *testing.T) {
+		err := service.CancelGuestUpdate(ctx, "test-id")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "client is not initialized")
+	})
+
+	t.Run("CancelGuestUpdateAsync_NilClient", func(t *testing.T) {
+		_, err := service.CancelGuestUpdateAsync("test-id")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "client is not initialized")
+	})
 }
 
 // TestTemplatesIntegration tests the client.Templates with real Nutanix API calls
@@ -219,4 +255,81 @@ func TestTemplatesErrorScenarios(t *testing.T) {
 		_, err := client.Templates.List(ctx, converged.WithFilter("invalid filter syntax"))
 		assert.Error(t, err)
 	})
+}
+
+// TestTemplatesGuestUpdateErrorScenarios tests guest update error handling with invalid inputs
+func TestTemplatesGuestUpdateErrorScenarios(t *testing.T) {
+	creds := testhelpers.CredentialsFromEnvironment(t)
+	if strings.Contains(creds.Endpoint, prismEndpointDummyValue) {
+		t.Skip("Skipping integration test: NUTANIX_ENDPOINT not set")
+	}
+
+	client, err := NewClient(creds)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	ctx := context.Background()
+
+	t.Run("InitiateGuestUpdate_NonExistentTemplate", func(t *testing.T) {
+		nonExistentUUID := "00000000-0000-0000-0000-000000000000"
+		_, err := client.Templates.InitiateGuestUpdate(ctx, nonExistentUUID, "")
+		assert.Error(t, err)
+	})
+
+	t.Run("CompleteGuestUpdate_NonExistentTemplate", func(t *testing.T) {
+		nonExistentUUID := "00000000-0000-0000-0000-000000000000"
+		_, err := client.Templates.CompleteGuestUpdate(ctx, nonExistentUUID, "v2", "test", true)
+		assert.Error(t, err)
+	})
+
+	t.Run("CancelGuestUpdate_NonExistentTemplate", func(t *testing.T) {
+		nonExistentUUID := "00000000-0000-0000-0000-000000000000"
+		err := client.Templates.CancelGuestUpdate(ctx, nonExistentUUID)
+		assert.Error(t, err)
+	})
+
+	t.Run("InitiateGuestUpdateAsync_NonExistentTemplate", func(t *testing.T) {
+		nonExistentUUID := "00000000-0000-0000-0000-000000000000"
+		_, err := client.Templates.InitiateGuestUpdateAsync(nonExistentUUID, "")
+		assert.Error(t, err)
+	})
+}
+
+// TestTemplatesGuestUpdateLifecycle tests the full guest update lifecycle:
+// initiate -> cancel. This requires a real template to exist on Prism Central.
+// Set NUTANIX_TEMPLATE_EXT_ID to the ext ID of a template to test against.
+func TestTemplatesGuestUpdateLifecycle(t *testing.T) {
+	creds := testhelpers.CredentialsFromEnvironment(t)
+	if strings.Contains(creds.Endpoint, prismEndpointDummyValue) {
+		t.Skip("Skipping integration test: NUTANIX_ENDPOINT not set")
+	}
+
+	templateExtID := testhelpers.GetEnvOrSkip(t, "NUTANIX_TEMPLATE_EXT_ID")
+
+	client, err := NewClient(creds)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	ctx := context.Background()
+
+	// Initiate guest update (creates temporary VM)
+	template, err := client.Templates.InitiateGuestUpdate(ctx, templateExtID, "")
+	require.NoError(t, err)
+	require.NotNil(t, template)
+	require.NotNil(t, template.GuestUpdateStatus)
+	require.NotNil(t, template.GuestUpdateStatus.DeployedVmReference)
+
+	tempVMUUID := *template.GuestUpdateStatus.DeployedVmReference
+	t.Logf("Guest update initiated, temporary VM: %s", tempVMUUID)
+	assert.NotEmpty(t, tempVMUUID)
+
+	// Cancel the guest update (cleans up temporary VM)
+	err = client.Templates.CancelGuestUpdate(ctx, templateExtID)
+	require.NoError(t, err)
+	t.Logf("Guest update cancelled successfully")
+
+	// Verify the template no longer has a pending guest update
+	updatedTemplate, err := client.Templates.Get(ctx, templateExtID)
+	require.NoError(t, err)
+	assert.Nil(t, updatedTemplate.GuestUpdateStatus)
 }

--- a/internal/testhelpers/creds.go
+++ b/internal/testhelpers/creds.go
@@ -110,6 +110,17 @@ func CredentialsFromEnvironment(t *testing.T) prismgoclient.Credentials {
 	}
 }
 
+// GetEnvOrSkip returns the value of the environment variable or skips the test
+// if the variable is not set or empty.
+func GetEnvOrSkip(t *testing.T, key string) string {
+	t.Helper()
+	val := os.Getenv(key)
+	if val == "" {
+		t.Skipf("Skipping: environment variable %s not set", key)
+	}
+	return val
+}
+
 // ManagementEndpointFromEnvironment returns a ManagementEndpoint object from the developer environment
 func ManagementEndpointFromEnvironment(t *testing.T) *types.ManagementEndpoint {
 	confFile, err := prismDevConfigFilePath()


### PR DESCRIPTION
## Add vmm/templates APIs for templates update

The PR adds new functions for the converged client allowing consumers to
start, cancel and finalize VM template Guest OS update process. All new
functions come in both sync and async flavours.

These new clints functions will later be used in:
https://github.com/nutanix-cloud-native/packer-plugin-nutanix/issues/302

## Testing

New tests were added to `test_templates.go`:
* Unit tests for nil-client and non-existent template guards
* integration tests requiring real Nutanix PC environment.

Additionally the updated client was used to build Nutanix Packer Plugin
and used with an actual Nutanix PC to run a VM template update process.
