### PR TITLE
feat!: add subnet IP reservation operations

### DIFF
--- a/converged/converged.go
+++ b/converged/converged.go
@@ -196,6 +196,7 @@ type Operation[T any] interface {
 	// Non-blocking results
 	Results() ([]*T, error)                // Returns results if complete, error if not ready
 	GetAffectedEntityRefs() ([]any, error) // Returns the affected entity references
+	GetCompletionDetails() ([]any, error)  // Returns the task completion details
 
 	// Non-blocking task states
 	IsDone() bool

--- a/converged/subnets.go
+++ b/converged/subnets.go
@@ -21,8 +21,12 @@ type Subnets[Subnet, TaskReference any] interface {
 	ReserveIpsBySubnetIdAsync(ctx context.Context, subnetExtId string, spec any) (Operation[NoEntity], error)
 
 	// UnreserveIpsBySubnetId unreserves IP addresses on a subnet and waits for completion.
+	// Returns the IP addresses that were unreserved, as reported by the completed task.
+	// This is primarily useful when unreserving by client context, where the caller does
+	// not know up front which IPs the server will release. The slice may be empty if the
+	// task does not report the unreserved IPs.
 	// spec should be of type *subnetModels.IpUnreserveSpec (for v4 implementation).
-	UnreserveIpsBySubnetId(ctx context.Context, subnetExtId string, spec any) error
+	UnreserveIpsBySubnetId(ctx context.Context, subnetExtId string, spec any) ([]string, error)
 
 	// UnreserveIpsBySubnetIdAsync unreserves IP addresses on a subnet and returns an Operation that can wait for completion.
 	// spec should be of type *subnetModels.IpUnreserveSpec (for v4 implementation).

--- a/converged/subnets.go
+++ b/converged/subnets.go
@@ -11,15 +11,22 @@ type Subnets[Subnet, TaskReference any] interface {
 	// Lister is the interface for List operations.
 	Lister[Subnet]
 
-	// ReserveIpsBySubnetId reserves IP addresses on a subnet.
-	// Returns a TaskReference that can be used to track the async operation.
+	// ReserveIpsBySubnetId reserves IP addresses on a subnet and waits for completion.
+	// Returns the reserved IP addresses from the completed task.
 	// spec should be of type *subnetModels.IpReserveSpec (for v4 implementation).
-	ReserveIpsBySubnetId(ctx context.Context, subnetExtId string, spec any) (*TaskReference, error)
+	ReserveIpsBySubnetId(ctx context.Context, subnetExtId string, spec any) ([]string, error)
 
-	// UnreserveIpsBySubnetId unreserves IP addresses on a subnet.
-	// Returns a TaskReference that can be used to track the async operation.
+	// ReserveIpsBySubnetIdAsync reserves IP addresses on a subnet and returns an Operation that can wait for completion.
+	// spec should be of type *subnetModels.IpReserveSpec (for v4 implementation).
+	ReserveIpsBySubnetIdAsync(ctx context.Context, subnetExtId string, spec any) (Operation[NoEntity], error)
+
+	// UnreserveIpsBySubnetId unreserves IP addresses on a subnet and waits for completion.
 	// spec should be of type *subnetModels.IpUnreserveSpec (for v4 implementation).
-	UnreserveIpsBySubnetId(ctx context.Context, subnetExtId string, spec any) (*TaskReference, error)
+	UnreserveIpsBySubnetId(ctx context.Context, subnetExtId string, spec any) error
+
+	// UnreserveIpsBySubnetIdAsync unreserves IP addresses on a subnet and returns an Operation that can wait for completion.
+	// spec should be of type *subnetModels.IpUnreserveSpec (for v4 implementation).
+	UnreserveIpsBySubnetIdAsync(ctx context.Context, subnetExtId string, spec any) (Operation[NoEntity], error)
 
 	// ListReservedIpsBySubnetId fetches a list of reserved IP addresses on a subnet.
 	ListReservedIpsBySubnetId(ctx context.Context, subnetExtId string, opts ...ODataOption) (any, error)

--- a/converged/v4/structs.go
+++ b/converged/v4/structs.go
@@ -14,17 +14,18 @@ import (
 	v4prismGoClient "github.com/nutanix-cloud-native/prism-go-client/v4"
 
 	clusterModels "github.com/nutanix/ntnx-api-golang-clients/clustermgmt-go-client/v4/models/clustermgmt/v4/config"
+	dpModels "github.com/nutanix/ntnx-api-golang-clients/datapolicies-go-client/v4/models/datapolicies/v4/config"
 	iamModels "github.com/nutanix/ntnx-api-golang-clients/iam-go-client/v4/models/iam/v4/authn"
 	alertModels "github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/monitoring/v4/serviceability"
 	subnetModels "github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4/models/networking/v4/config"
 	networkingprismapi "github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4/models/prism/v4/config"
+	commonModels "github.com/nutanix/ntnx-api-golang-clients/prism-go-client/v4/models/common/v1/config"
 	prismModels "github.com/nutanix/ntnx-api-golang-clients/prism-go-client/v4/models/prism/v4/config"
 	prismErrors "github.com/nutanix/ntnx-api-golang-clients/prism-go-client/v4/models/prism/v4/error"
 	vmmModels "github.com/nutanix/ntnx-api-golang-clients/vmm-go-client/v4/models/vmm/v4/ahv/config"
 	policyModels "github.com/nutanix/ntnx-api-golang-clients/vmm-go-client/v4/models/vmm/v4/ahv/policies"
 	imageModels "github.com/nutanix/ntnx-api-golang-clients/vmm-go-client/v4/models/vmm/v4/content"
 	volumeModels "github.com/nutanix/ntnx-api-golang-clients/volumes-go-client/v4/models/volumes/v4/config"
-	dpModels "github.com/nutanix/ntnx-api-golang-clients/datapolicies-go-client/v4/models/datapolicies/v4/config"
 	"k8s.io/utils/ptr"
 )
 
@@ -134,6 +135,7 @@ func NewClientFromV4SDKClient(v4sdkClient *v4prismGoClient.Client) *Client {
 type Operation[T any] struct {
 	lock               *sync.Mutex
 	affectedEntityRefs []prismModels.EntityReference
+	completionDetails  []commonModels.KVPair
 	entityUUIDs        []string
 	entitiesAffected   int
 	taskUUID           string
@@ -216,6 +218,9 @@ func (o *Operation[T]) Wait(ctx context.Context) ([]*T, error) {
 		if task.EntitiesAffected != nil {
 			o.setEntitiesAffected(len(task.EntitiesAffected))
 			o.setAffectedEntityRefs(task.EntitiesAffected)
+		}
+		if task.CompletionDetails != nil {
+			o.setCompletionDetails(task.CompletionDetails)
 		}
 
 		for _, entityRef := range task.EntitiesAffected {
@@ -309,6 +314,22 @@ func (o *Operation[T]) GetAffectedEntityRefs() ([]any, error) {
 		entityRefs[i] = &entityRef
 	}
 	return entityRefs, nil
+}
+
+func (o *Operation[T]) setCompletionDetails(details []commonModels.KVPair) {
+	o.lock.Lock()
+	defer o.lock.Unlock()
+	o.completionDetails = slices.Clone(details)
+}
+
+func (o *Operation[T]) GetCompletionDetails() ([]any, error) {
+	o.lock.Lock()
+	defer o.lock.Unlock()
+	details := make([]any, len(o.completionDetails))
+	for i, detail := range o.completionDetails {
+		details[i] = &detail
+	}
+	return details, nil
 }
 
 func (o *Operation[T]) setEntitiesAffected(count int) {

--- a/converged/v4/subnets.go
+++ b/converged/v4/subnets.go
@@ -15,7 +15,16 @@ import (
 	prismModels "github.com/nutanix/ntnx-api-golang-clients/prism-go-client/v4/models/common/v1/config"
 )
 
-const reservedIPsTaskKey = "reserved_ips"
+const (
+	// completionDetailsIPsKey is the name of the KVPair that Prism Central adds
+	// to a subnet IP reserve/unreserve task's completion details. PC reuses the
+	// same KVPair name for both operations.
+	completionDetailsIPsKey = "reserved_or_unreserved_ips"
+
+	// reservedIPsValueField is the field inside that KVPair's JSON value that
+	// lists the reserved IP addresses, e.g. {"reserved_ips": [...]}.
+	reservedIPsValueField = "reserved_ips"
+)
 
 // SubnetsService provides implementation for all Subnets interface methods.
 type SubnetsService struct {
@@ -272,12 +281,29 @@ func reservedIPsFromCompletionDetails(operation converged.Operation[converged.No
 		return nil, fmt.Errorf("failed to get task completion details: %w", err)
 	}
 
+	ips, found, err := reservedIPsFromDetails(details)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, fmt.Errorf("task %s completion details missing reserved IPs", operation.UUID())
+	}
+
+	return ips, nil
+}
+
+// reservedIPsFromDetails extracts the reserved IP addresses from a subnet IP
+// reserve task's completion details. The IPs live in the KVPair named
+// completionDetailsIPsKey, whose value is a JSON document keyed by
+// reservedIPsValueField. The returned bool reports whether such a KVPair was
+// found.
+func reservedIPsFromDetails(details []any) ([]string, bool, error) {
 	for _, rawDetail := range details {
 		detail, ok := rawDetail.(*prismModels.KVPair)
 		if !ok || detail == nil {
 			continue
 		}
-		if detail.Name == nil || *detail.Name != reservedIPsTaskKey || detail.Value == nil {
+		if detail.Name == nil || *detail.Name != completionDetailsIPsKey || detail.Value == nil {
 			continue
 		}
 		value := detail.Value.GetValue()
@@ -288,18 +314,15 @@ func reservedIPsFromCompletionDetails(operation converged.Operation[converged.No
 		marshaledValue, _ := json.Marshal(value)
 		unquotedValue, err := strconv.Unquote(string(marshaledValue))
 		if err != nil {
-			return nil, fmt.Errorf("failed to unquote reserved IP response %s: %w", marshaledValue, err)
+			return nil, false, fmt.Errorf("failed to unquote reserved IP response %s: %w", marshaledValue, err)
 		}
 
-		type reservedIPs struct {
-			ReservedIPs []string `json:"reserved_ips"`
-		}
-		var response reservedIPs
+		var response map[string][]string
 		if err := json.Unmarshal([]byte(unquotedValue), &response); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal reserved IP response %s: %w", unquotedValue, err)
+			return nil, false, fmt.Errorf("failed to unmarshal reserved IP response %s: %w", unquotedValue, err)
 		}
-		return response.ReservedIPs, nil
+		return response[reservedIPsValueField], true, nil
 	}
 
-	return nil, fmt.Errorf("task %s completion details missing reserved IPs", operation.UUID())
+	return nil, false, nil
 }

--- a/converged/v4/subnets.go
+++ b/converged/v4/subnets.go
@@ -2,15 +2,20 @@ package v4
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 
 	converged "github.com/nutanix-cloud-native/prism-go-client/converged"
 	v4prismGoClient "github.com/nutanix-cloud-native/prism-go-client/v4"
 
 	subnetModels "github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4/models/networking/v4/config"
 	networkingprismapi "github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4/models/prism/v4/config"
+	prismModels "github.com/nutanix/ntnx-api-golang-clients/prism-go-client/v4/models/prism/v4/config"
 )
+
+const reservedIPsTaskKey = "reserved_ips"
 
 // SubnetsService provides implementation for all Subnets interface methods.
 type SubnetsService struct {
@@ -91,13 +96,32 @@ func (s *SubnetsService) NewIterator(ctx context.Context, opts ...converged.ODat
 	)
 }
 
-// ReserveIpsBySubnetId reserves IP addresses on a subnet.
-// It returns a TaskReference that can be used to track the async operation.
+// ReserveIpsBySubnetId reserves IP addresses on a subnet and waits for completion.
+// It returns the reserved IP addresses from the completed task.
 func (s *SubnetsService) ReserveIpsBySubnetId(
 	ctx context.Context,
 	subnetExtId string,
 	spec any,
-) (*networkingprismapi.TaskReference, error) {
+) ([]string, error) {
+	operation, err := s.ReserveIpsBySubnetIdAsync(ctx, subnetExtId, spec)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := operation.Wait(ctx); err != nil {
+		return nil, fmt.Errorf("failed to reserve IPs for subnet %s: %w", subnetExtId, err)
+	}
+
+	return s.reservedIPsFromTask(ctx, operation.UUID())
+}
+
+// ReserveIpsBySubnetIdAsync reserves IP addresses on a subnet.
+// It returns an Operation that can be used to wait for the async task completion.
+func (s *SubnetsService) ReserveIpsBySubnetIdAsync(
+	ctx context.Context,
+	subnetExtId string,
+	spec any,
+) (converged.Operation[converged.NoEntity], error) {
 	if s.client == nil {
 		return nil, errors.New("client is not initialized")
 	}
@@ -123,16 +147,44 @@ func (s *SubnetsService) ReserveIpsBySubnetId(
 		return nil, fmt.Errorf("failed to reserve IPs for subnet %s: %w", subnetExtId, err)
 	}
 
-	return &taskRef, nil
+	if taskRef.ExtId == nil {
+		return nil, fmt.Errorf("task reference ExtId is nil for reserved IPs")
+	}
+
+	return NewOperation(
+		*taskRef.ExtId,
+		s.client,
+		func(ctx context.Context, uuid string) (*converged.NoEntity, error) {
+			return converged.NoEntityGetter(ctx, uuid)
+		},
+	), nil
 }
 
-// UnreserveIpsBySubnetId unreserves IP addresses on a subnet.
-// It returns a TaskReference that can be used to track the async operation.
+// UnreserveIpsBySubnetId unreserves IP addresses on a subnet and waits for completion.
 func (s *SubnetsService) UnreserveIpsBySubnetId(
 	ctx context.Context,
 	subnetExtId string,
 	spec any,
-) (*networkingprismapi.TaskReference, error) {
+) error {
+	operation, err := s.UnreserveIpsBySubnetIdAsync(ctx, subnetExtId, spec)
+	if err != nil {
+		return err
+	}
+
+	if _, err := operation.Wait(ctx); err != nil {
+		return fmt.Errorf("failed to unreserve IPs for subnet %s: %w", subnetExtId, err)
+	}
+
+	return nil
+}
+
+// UnreserveIpsBySubnetIdAsync unreserves IP addresses on a subnet.
+// It returns an Operation that can be used to wait for the async task completion.
+func (s *SubnetsService) UnreserveIpsBySubnetIdAsync(
+	ctx context.Context,
+	subnetExtId string,
+	spec any,
+) (converged.Operation[converged.NoEntity], error) {
 	if s.client == nil {
 		return nil, errors.New("client is not initialized")
 	}
@@ -158,7 +210,17 @@ func (s *SubnetsService) UnreserveIpsBySubnetId(
 		return nil, fmt.Errorf("failed to unreserve IPs for subnet %s: %w", subnetExtId, err)
 	}
 
-	return &taskRef, nil
+	if taskRef.ExtId == nil {
+		return nil, fmt.Errorf("task reference ExtId is nil for unreserved IPs")
+	}
+
+	return NewOperation(
+		*taskRef.ExtId,
+		s.client,
+		func(ctx context.Context, uuid string) (*converged.NoEntity, error) {
+			return converged.NoEntityGetter(ctx, uuid)
+		},
+	), nil
 }
 
 // ListReservedIpsBySubnetId fetches a list of reserved IP addresses on a particular managed subnet.
@@ -202,4 +264,40 @@ func (s *SubnetsService) ListReservedIpsBySubnetId(
 	}
 
 	return resp, nil
+}
+
+func (s *SubnetsService) reservedIPsFromTask(ctx context.Context, taskID string) ([]string, error) {
+	task, err := CallAPI[*prismModels.GetTaskApiResponse, prismModels.Task](
+		s.client.TasksApiInstance.GetTaskById(&taskID, nil),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get completed task %s: %w", taskID, err)
+	}
+
+	for _, detail := range task.CompletionDetails {
+		if detail.Name == nil || *detail.Name != reservedIPsTaskKey || detail.Value == nil {
+			continue
+		}
+		value := detail.Value.GetValue()
+		if value == nil {
+			continue
+		}
+
+		marshaledValue, _ := json.Marshal(value)
+		unquotedValue, err := strconv.Unquote(string(marshaledValue))
+		if err != nil {
+			return nil, fmt.Errorf("failed to unquote reserved IP response %s: %w", marshaledValue, err)
+		}
+
+		type reservedIPs struct {
+			ReservedIPs []string `json:"reserved_ips"`
+		}
+		var response reservedIPs
+		if err := json.Unmarshal([]byte(unquotedValue), &response); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal reserved IP response %s: %w", unquotedValue, err)
+		}
+		return response.ReservedIPs, nil
+	}
+
+	return nil, fmt.Errorf("task %s completion details missing reserved IPs", taskID)
 }

--- a/converged/v4/subnets.go
+++ b/converged/v4/subnets.go
@@ -22,8 +22,12 @@ const (
 	completionDetailsIPsKey = "reserved_or_unreserved_ips"
 
 	// reservedIPsValueField is the field inside that KVPair's JSON value that
-	// lists the reserved IP addresses, e.g. {"reserved_ips": [...]}.
+	// lists the IPs of a reserve task, e.g. {"reserved_ips": [...]}.
 	reservedIPsValueField = "reserved_ips"
+
+	// unreservedIPsValueField is the field inside that KVPair's JSON value that
+	// lists the IPs of an unreserve task, e.g. {"unreserved_ips": [...]}.
+	unreservedIPsValueField = "unreserved_ips"
 )
 
 // SubnetsService provides implementation for all Subnets interface methods.
@@ -121,7 +125,15 @@ func (s *SubnetsService) ReserveIpsBySubnetId(
 		return nil, fmt.Errorf("failed to reserve IPs for subnet %s: %w", subnetExtId, err)
 	}
 
-	return reservedIPsFromCompletionDetails(operation)
+	ips, found, err := ipsFromCompletionDetails(operation, reservedIPsValueField)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, fmt.Errorf("task %s completion details missing reserved IPs", operation.UUID())
+	}
+
+	return ips, nil
 }
 
 // ReserveIpsBySubnetIdAsync reserves IP addresses on a subnet.
@@ -169,22 +181,32 @@ func (s *SubnetsService) ReserveIpsBySubnetIdAsync(
 	), nil
 }
 
-// UnreserveIpsBySubnetId unreserves IP addresses on a subnet and waits for completion.
+// UnreserveIpsBySubnetId unreserves IP addresses on a subnet and waits for
+// completion. It returns the IP addresses that were unreserved, as reported by
+// the completed task. This is primarily useful when unreserving by client
+// context, where the caller does not know up front which IPs the server will
+// release. The returned slice may be empty if the task does not report the
+// unreserved IPs; a missing list is not treated as an error.
 func (s *SubnetsService) UnreserveIpsBySubnetId(
 	ctx context.Context,
 	subnetExtId string,
 	spec any,
-) error {
+) ([]string, error) {
 	operation, err := s.UnreserveIpsBySubnetIdAsync(ctx, subnetExtId, spec)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if _, err := operation.Wait(ctx); err != nil {
-		return fmt.Errorf("failed to unreserve IPs for subnet %s: %w", subnetExtId, err)
+		return nil, fmt.Errorf("failed to unreserve IPs for subnet %s: %w", subnetExtId, err)
 	}
 
-	return nil
+	ips, _, err := ipsFromCompletionDetails(operation, unreservedIPsValueField)
+	if err != nil {
+		return nil, err
+	}
+
+	return ips, nil
 }
 
 // UnreserveIpsBySubnetIdAsync unreserves IP addresses on a subnet.
@@ -275,29 +297,24 @@ func (s *SubnetsService) ListReservedIpsBySubnetId(
 	return resp, nil
 }
 
-func reservedIPsFromCompletionDetails(operation converged.Operation[converged.NoEntity]) ([]string, error) {
+func ipsFromCompletionDetails(
+	operation converged.Operation[converged.NoEntity],
+	valueField string,
+) ([]string, bool, error) {
 	details, err := operation.GetCompletionDetails()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get task completion details: %w", err)
+		return nil, false, fmt.Errorf("failed to get task completion details: %w", err)
 	}
 
-	ips, found, err := reservedIPsFromDetails(details)
-	if err != nil {
-		return nil, err
-	}
-	if !found {
-		return nil, fmt.Errorf("task %s completion details missing reserved IPs", operation.UUID())
-	}
-
-	return ips, nil
+	return ipsFromDetails(details, valueField)
 }
 
-// reservedIPsFromDetails extracts the reserved IP addresses from a subnet IP
-// reserve task's completion details. The IPs live in the KVPair named
-// completionDetailsIPsKey, whose value is a JSON document keyed by
-// reservedIPsValueField. The returned bool reports whether such a KVPair was
-// found.
-func reservedIPsFromDetails(details []any) ([]string, bool, error) {
+// ipsFromDetails extracts IP addresses from a subnet IP reserve/unreserve task's
+// completion details. The IPs live in the KVPair named completionDetailsIPsKey,
+// whose value is a JSON document keyed by valueField (reservedIPsValueField for
+// reserve tasks, unreservedIPsValueField for unreserve tasks). The returned bool
+// reports whether the KVPair carrying valueField was found.
+func ipsFromDetails(details []any, valueField string) ([]string, bool, error) {
 	for _, rawDetail := range details {
 		detail, ok := rawDetail.(*prismModels.KVPair)
 		if !ok || detail == nil {
@@ -314,14 +331,18 @@ func reservedIPsFromDetails(details []any) ([]string, bool, error) {
 		marshaledValue, _ := json.Marshal(value)
 		unquotedValue, err := strconv.Unquote(string(marshaledValue))
 		if err != nil {
-			return nil, false, fmt.Errorf("failed to unquote reserved IP response %s: %w", marshaledValue, err)
+			return nil, false, fmt.Errorf("failed to unquote IP response %s: %w", marshaledValue, err)
 		}
 
 		var response map[string][]string
 		if err := json.Unmarshal([]byte(unquotedValue), &response); err != nil {
-			return nil, false, fmt.Errorf("failed to unmarshal reserved IP response %s: %w", unquotedValue, err)
+			return nil, false, fmt.Errorf("failed to unmarshal IP response %s: %w", unquotedValue, err)
 		}
-		return response[reservedIPsValueField], true, nil
+		ips, ok := response[valueField]
+		if !ok {
+			continue
+		}
+		return ips, true, nil
 	}
 
 	return nil, false, nil

--- a/converged/v4/subnets.go
+++ b/converged/v4/subnets.go
@@ -12,7 +12,7 @@ import (
 
 	subnetModels "github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4/models/networking/v4/config"
 	networkingprismapi "github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4/models/prism/v4/config"
-	prismModels "github.com/nutanix/ntnx-api-golang-clients/prism-go-client/v4/models/prism/v4/config"
+	prismModels "github.com/nutanix/ntnx-api-golang-clients/prism-go-client/v4/models/common/v1/config"
 )
 
 const reservedIPsTaskKey = "reserved_ips"
@@ -112,7 +112,7 @@ func (s *SubnetsService) ReserveIpsBySubnetId(
 		return nil, fmt.Errorf("failed to reserve IPs for subnet %s: %w", subnetExtId, err)
 	}
 
-	return s.reservedIPsFromTask(ctx, operation.UUID())
+	return reservedIPsFromCompletionDetails(operation)
 }
 
 // ReserveIpsBySubnetIdAsync reserves IP addresses on a subnet.
@@ -266,15 +266,17 @@ func (s *SubnetsService) ListReservedIpsBySubnetId(
 	return resp, nil
 }
 
-func (s *SubnetsService) reservedIPsFromTask(ctx context.Context, taskID string) ([]string, error) {
-	task, err := CallAPI[*prismModels.GetTaskApiResponse, prismModels.Task](
-		s.client.TasksApiInstance.GetTaskById(&taskID, nil),
-	)
+func reservedIPsFromCompletionDetails(operation converged.Operation[converged.NoEntity]) ([]string, error) {
+	details, err := operation.GetCompletionDetails()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get completed task %s: %w", taskID, err)
+		return nil, fmt.Errorf("failed to get task completion details: %w", err)
 	}
 
-	for _, detail := range task.CompletionDetails {
+	for _, rawDetail := range details {
+		detail, ok := rawDetail.(*prismModels.KVPair)
+		if !ok || detail == nil {
+			continue
+		}
 		if detail.Name == nil || *detail.Name != reservedIPsTaskKey || detail.Value == nil {
 			continue
 		}
@@ -299,5 +301,5 @@ func (s *SubnetsService) reservedIPsFromTask(ctx context.Context, taskID string)
 		return response.ReservedIPs, nil
 	}
 
-	return nil, fmt.Errorf("task %s completion details missing reserved IPs", taskID)
+	return nil, fmt.Errorf("task %s completion details missing reserved IPs", operation.UUID())
 }

--- a/converged/v4/subnets_test.go
+++ b/converged/v4/subnets_test.go
@@ -1,0 +1,79 @@
+// Copyright 2026 Nutanix. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package v4
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	prismModels "github.com/nutanix/ntnx-api-golang-clients/prism-go-client/v4/models/common/v1/config"
+)
+
+func kvPair(t *testing.T, name, value string) *prismModels.KVPair {
+	t.Helper()
+	kv := prismModels.NewKVPair()
+	kv.Name = &name
+	require.NoError(t, kv.SetValue(value))
+	return kv
+}
+
+func TestReservedIPsFromDetails(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		details   []any
+		wantIPs   []string
+		wantFound bool
+		wantErr   bool
+	}{
+		{
+			name: "reserve task completion details",
+			details: []any{
+				// Prism Central uses the key "reserved_or_unreserved_ips" for both
+				// reserve and unreserve tasks; the value is a JSON document.
+				kvPair(t, completionDetailsIPsKey, `{"reserved_ips": ["10.23.132.71"]}`),
+			},
+			wantIPs:   []string{"10.23.132.71"},
+			wantFound: true,
+		},
+		{
+			name: "multiple reserved IPs",
+			details: []any{
+				kvPair(t, completionDetailsIPsKey, `{"reserved_ips": ["10.0.0.1", "10.0.0.2"]}`),
+			},
+			wantIPs:   []string{"10.0.0.1", "10.0.0.2"},
+			wantFound: true,
+		},
+		{
+			name: "unrelated KVPair is ignored",
+			details: []any{
+				kvPair(t, "some_other_key", `{"reserved_ips": ["10.0.0.1"]}`),
+			},
+			wantFound: false,
+		},
+		{
+			name:      "no completion details",
+			details:   nil,
+			wantFound: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ips, found, err := reservedIPsFromDetails(tt.details)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantFound, found)
+			assert.Equal(t, tt.wantIPs, ips)
+		})
+	}
+}

--- a/converged/v4/subnets_test.go
+++ b/converged/v4/subnets_test.go
@@ -20,45 +20,68 @@ func kvPair(t *testing.T, name, value string) *prismModels.KVPair {
 	return kv
 }
 
-func TestReservedIPsFromDetails(t *testing.T) {
+func TestIPsFromDetails(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
-		details   []any
-		wantIPs   []string
-		wantFound bool
-		wantErr   bool
+		name       string
+		details    []any
+		valueField string
+		wantIPs    []string
+		wantFound  bool
+		wantErr    bool
 	}{
 		{
 			name: "reserve task completion details",
 			details: []any{
-				// Prism Central uses the key "reserved_or_unreserved_ips" for both
-				// reserve and unreserve tasks; the value is a JSON document.
+				// Prism Central uses the KVPair name "reserved_or_unreserved_ips"
+				// for both reserve and unreserve tasks; only the inner JSON key
+				// differs (reserved_ips vs unreserved_ips).
 				kvPair(t, completionDetailsIPsKey, `{"reserved_ips": ["10.23.132.71"]}`),
 			},
-			wantIPs:   []string{"10.23.132.71"},
-			wantFound: true,
+			valueField: reservedIPsValueField,
+			wantIPs:    []string{"10.23.132.71"},
+			wantFound:  true,
 		},
 		{
 			name: "multiple reserved IPs",
 			details: []any{
 				kvPair(t, completionDetailsIPsKey, `{"reserved_ips": ["10.0.0.1", "10.0.0.2"]}`),
 			},
-			wantIPs:   []string{"10.0.0.1", "10.0.0.2"},
-			wantFound: true,
+			valueField: reservedIPsValueField,
+			wantIPs:    []string{"10.0.0.1", "10.0.0.2"},
+			wantFound:  true,
+		},
+		{
+			name: "unreserve task completion details",
+			details: []any{
+				kvPair(t, completionDetailsIPsKey, `{"unreserved_ips": ["10.23.132.6"]}`),
+			},
+			valueField: unreservedIPsValueField,
+			wantIPs:    []string{"10.23.132.6"},
+			wantFound:  true,
+		},
+		{
+			name: "reserve value field absent for unreserve lookup",
+			details: []any{
+				kvPair(t, completionDetailsIPsKey, `{"reserved_ips": ["10.0.0.1"]}`),
+			},
+			valueField: unreservedIPsValueField,
+			wantFound:  false,
 		},
 		{
 			name: "unrelated KVPair is ignored",
 			details: []any{
 				kvPair(t, "some_other_key", `{"reserved_ips": ["10.0.0.1"]}`),
 			},
-			wantFound: false,
+			valueField: reservedIPsValueField,
+			wantFound:  false,
 		},
 		{
-			name:      "no completion details",
-			details:   nil,
-			wantFound: false,
+			name:       "no completion details",
+			details:    nil,
+			valueField: reservedIPsValueField,
+			wantFound:  false,
 		},
 	}
 
@@ -66,7 +89,7 @@ func TestReservedIPsFromDetails(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			ips, found, err := reservedIPsFromDetails(tt.details)
+			ips, found, err := ipsFromDetails(tt.details, tt.valueField)
 			if tt.wantErr {
 				require.Error(t, err)
 				return


### PR DESCRIPTION
## Summary
- Make converged subnet reserve/unreserve sync methods wait for Prism task completion.
- Add async subnet reserve/unreserve methods that return `converged.Operation` for callers that need task lifecycle control.
- Return reserved IP strings from sync reserve and simplify sync unreserve to return only an error.

## Breaking change
`ReserveIpsBySubnetId` now returns `[]string` instead of `*TaskReference`, and `UnreserveIpsBySubnetId` now returns only `error`. Use `ReserveIpsBySubnetIdAsync` or `UnreserveIpsBySubnetIdAsync` when callers need the Prism task operation.

Made with [Cursor](https://cursor.com)