### PR TITLE
feat: add manage alert apis

### DIFF
--- a/converged/alerts.go
+++ b/converged/alerts.go
@@ -1,5 +1,7 @@
 package converged
 
+import "context"
+
 // Alerts defines the interface for managing alerts.
 type Alerts[Alert any] interface {
 	// Getter is the interface for Get operations.
@@ -7,4 +9,12 @@ type Alerts[Alert any] interface {
 
 	// Lister is the interface for List operations.
 	Lister[Alert]
+
+	// Acknowledge acknowledges the alert identified by the given external
+	// identifier and returns the asynchronous task operation.
+	Acknowledge(ctx context.Context, uuid string) (Operation[Alert], error)
+
+	// Resolve resolves the alert identified by the given external identifier
+	// and returns the asynchronous task operation.
+	Resolve(ctx context.Context, uuid string) (Operation[Alert], error)
 }

--- a/converged/alerts.go
+++ b/converged/alerts.go
@@ -2,6 +2,25 @@ package converged
 
 import "context"
 
+// AlertAction is the action to perform on an alert through the manage-alert
+// operation. Its values map one-to-one to the actionType parameter of the
+// .../serviceability/alerts/{extId}/$actions/manage-alert API.
+type AlertAction string
+
+const (
+	// AlertActionResolve resolves an open alert.
+	AlertActionResolve AlertAction = "RESOLVE"
+
+	// AlertActionAcknowledge acknowledges an open alert.
+	AlertActionAcknowledge AlertAction = "ACKNOWLEDGE"
+
+	// AlertActionUnknown represents an unknown value.
+	AlertActionUnknown AlertAction = "$UNKNOWN"
+
+	// AlertActionRedacted represents a redacted value.
+	AlertActionRedacted AlertAction = "$REDACTED"
+)
+
 // Alerts defines the interface for managing alerts.
 type Alerts[Alert any] interface {
 	// Getter is the interface for Get operations.
@@ -10,11 +29,12 @@ type Alerts[Alert any] interface {
 	// Lister is the interface for List operations.
 	Lister[Alert]
 
-	// Acknowledge acknowledges the alert identified by the given external
-	// identifier and returns the asynchronous task operation.
-	Acknowledge(ctx context.Context, uuid string) (Operation[Alert], error)
+	// ManageAlert performs the given action (e.g. acknowledge or resolve) on
+	// the entity identified by the given external identifier, waits for the
+	// task to complete, and returns the updated entity.
+	ManageAlert(ctx context.Context, uuid string, action AlertAction) (*Alert, error)
 
-	// Resolve resolves the alert identified by the given external identifier
-	// and returns the asynchronous task operation.
-	Resolve(ctx context.Context, uuid string) (Operation[Alert], error)
+	// ManageAlertAsync performs the given action on the entity identified by
+	// the given external identifier and returns an Operation to track the task.
+	ManageAlertAsync(ctx context.Context, uuid string, action AlertAction) (Operation[Alert], error)
 }

--- a/converged/v4/alerts.go
+++ b/converged/v4/alerts.go
@@ -11,8 +11,8 @@ import (
 	monitoringApi "github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/api"
 	alertsReq "github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/monitoring/v4/request/alerts"
 	manageAlertsReq "github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/monitoring/v4/request/managealerts"
-	monitoringPrismConfig "github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/prism/v4/config"
 	alertModels "github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/monitoring/v4/serviceability"
+	monitoringPrismConfig "github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/prism/v4/config"
 )
 
 // AlertsService provides implementation for all Alerts interface methods.
@@ -126,6 +126,16 @@ func (s *AlertsService) ManageAlertAsync(ctx context.Context, uuid string,
 		return nil, fmt.Errorf("unsupported %s action: %q", s.entitiesName, action)
 	}
 
+	// The manage-alert endpoint requires an If-Match ETag header to guard
+	// against concurrent modifications.
+	_, args, err := GetEntityAndEtag(
+		s.client.AlertsServiceApiInstance.GetAlertById(ctx,
+			&alertsReq.GetAlertByIdRequest{ExtId: &uuid}),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get %s for manage: %w", s.entitiesName, err)
+	}
+
 	spec := alertModels.NewAlertActionSpec()
 	spec.ActionType = &actionType
 
@@ -138,7 +148,7 @@ func (s *AlertsService) ManageAlertAsync(ctx context.Context, uuid string,
 		manageAlertsApi.ManageAlert(ctx, &manageAlertsReq.ManageAlertRequest{
 			ExtId: &uuid,
 			Body:  spec,
-		}),
+		}, args),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to manage %s: %w", s.entitiesName, err)

--- a/converged/v4/alerts.go
+++ b/converged/v4/alerts.go
@@ -8,7 +8,10 @@ import (
 	converged "github.com/nutanix-cloud-native/prism-go-client/converged"
 	v4prismGoClient "github.com/nutanix-cloud-native/prism-go-client/v4"
 
+	monitoringApi "github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/api"
 	alertsReq "github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/monitoring/v4/request/alerts"
+	manageAlertsReq "github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/monitoring/v4/request/managealerts"
+	monitoringPrismConfig "github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/prism/v4/config"
 	alertModels "github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/monitoring/v4/serviceability"
 )
 
@@ -76,6 +79,60 @@ func (s *AlertsService) List(ctx context.Context,
 		opts,
 		s.entitiesName,
 	)
+}
+
+// Acknowledge acknowledges the alert identified by the given external
+// identifier. It returns an asynchronous operation tracking the resulting task.
+func (s *AlertsService) Acknowledge(ctx context.Context, uuid string) (
+	converged.Operation[alertModels.Alert], error) {
+
+	return s.manageAlert(ctx, uuid, alertModels.ACTIONTYPE_ACKNOWLEDGE)
+}
+
+// Resolve resolves the alert identified by the given external identifier.
+// It returns an asynchronous operation tracking the resulting task.
+func (s *AlertsService) Resolve(ctx context.Context, uuid string) (
+	converged.Operation[alertModels.Alert], error) {
+
+	return s.manageAlert(ctx, uuid, alertModels.ACTIONTYPE_RESOLVE)
+}
+
+// manageAlert performs the requested action (acknowledge or resolve) on the
+// alert identified by the given external identifier.
+func (s *AlertsService) manageAlert(ctx context.Context, uuid string,
+	action alertModels.ActionType) (converged.Operation[alertModels.Alert], error) {
+
+	if s.client == nil || s.client.AlertsServiceApiInstance == nil {
+		return nil, errors.New("client is not initialized")
+	}
+
+	spec := alertModels.NewAlertActionSpec()
+	spec.ActionType = &action
+
+	// The acknowledge/resolve operations live on a separate generated API
+	// (ManageAlertsServiceApi). Build it from the alerts API's underlying
+	// client so we don't need to thread an extra instance through the SDK.
+	manageAlertsApi := monitoringApi.NewManageAlertsServiceApi(s.client.AlertsServiceApiInstance.ApiClient)
+
+	taskRef, err := CallAPI[*alertModels.ManageAlertApiResponse, monitoringPrismConfig.TaskReference](
+		manageAlertsApi.ManageAlert(ctx, &manageAlertsReq.ManageAlertRequest{
+			ExtId: &uuid,
+			Body:  spec,
+		}),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to manage %s: %w", s.entitiesName, err)
+	}
+
+	if taskRef.ExtId == nil {
+		return nil, fmt.Errorf("task reference ExtId is nil for managed %s", s.entitiesName)
+	}
+
+	return NewOperation(
+		*taskRef.ExtId,
+		s.client,
+		s.Get,
+	), nil
 }
 
 // NewIterator returns an iterator for listing alerts.

--- a/converged/v4/alerts.go
+++ b/converged/v4/alerts.go
@@ -81,35 +81,55 @@ func (s *AlertsService) List(ctx context.Context,
 	)
 }
 
-// Acknowledge acknowledges the alert identified by the given external
-// identifier. It returns an asynchronous operation tracking the resulting task.
-func (s *AlertsService) Acknowledge(ctx context.Context, uuid string) (
-	converged.Operation[alertModels.Alert], error) {
-
-	return s.manageAlert(ctx, uuid, alertModels.ACTIONTYPE_ACKNOWLEDGE)
+// alertActionMap maps the service-agnostic converged.AlertAction values to the
+// V4 SDK ActionType enum used by the manage-alert API.
+var alertActionMap = map[converged.AlertAction]alertModels.ActionType{
+	converged.AlertActionResolve:     alertModels.ACTIONTYPE_RESOLVE,
+	converged.AlertActionAcknowledge: alertModels.ACTIONTYPE_ACKNOWLEDGE,
+	converged.AlertActionUnknown:     alertModels.ACTIONTYPE_UNKNOWN,
+	converged.AlertActionRedacted:    alertModels.ACTIONTYPE_REDACTED,
 }
 
-// Resolve resolves the alert identified by the given external identifier.
-// It returns an asynchronous operation tracking the resulting task.
-func (s *AlertsService) Resolve(ctx context.Context, uuid string) (
-	converged.Operation[alertModels.Alert], error) {
+// ManageAlert performs the given action on the alert identified by the given
+// external identifier, waits for the resulting task to finish, and re-reads the
+// entity by its external identifier so the returned value reflects the new state.
+func (s *AlertsService) ManageAlert(ctx context.Context, uuid string,
+	action converged.AlertAction) (*alertModels.Alert, error) {
 
-	return s.manageAlert(ctx, uuid, alertModels.ACTIONTYPE_RESOLVE)
+	if s.client == nil {
+		return nil, errors.New("client is not initialized")
+	}
+
+	operation, err := s.ManageAlertAsync(ctx, uuid, action)
+	if err != nil {
+		return nil, fmt.Errorf("failed to manage %s: %w", s.entitiesName, err)
+	}
+
+	if _, err := operation.Wait(ctx); err != nil {
+		return nil, fmt.Errorf("failed to manage %s: %w", s.entitiesName, err)
+	}
+
+	return s.Get(ctx, uuid)
 }
 
-// manageAlert performs the requested action (acknowledge or resolve) on the
-// alert identified by the given external identifier.
-func (s *AlertsService) manageAlert(ctx context.Context, uuid string,
-	action alertModels.ActionType) (converged.Operation[alertModels.Alert], error) {
+// ManageAlertAsync performs the given action on the alert identified by the
+// given external identifier and returns an Operation to track the task.
+func (s *AlertsService) ManageAlertAsync(ctx context.Context, uuid string,
+	action converged.AlertAction) (converged.Operation[alertModels.Alert], error) {
 
 	if s.client == nil || s.client.AlertsServiceApiInstance == nil {
 		return nil, errors.New("client is not initialized")
 	}
 
-	spec := alertModels.NewAlertActionSpec()
-	spec.ActionType = &action
+	actionType, ok := alertActionMap[action]
+	if !ok {
+		return nil, fmt.Errorf("unsupported %s action: %q", s.entitiesName, action)
+	}
 
-	// The acknowledge/resolve operations live on a separate generated API
+	spec := alertModels.NewAlertActionSpec()
+	spec.ActionType = &actionType
+
+	// The manage-alert operation lives on a separate generated API
 	// (ManageAlertsServiceApi). Build it from the alerts API's underlying
 	// client so we don't need to thread an extra instance through the SDK.
 	manageAlertsApi := monitoringApi.NewManageAlertsServiceApi(s.client.AlertsServiceApiInstance.ApiClient)

--- a/converged/v4/alerts_test.go
+++ b/converged/v4/alerts_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	prismgoclient "github.com/nutanix-cloud-native/prism-go-client"
 	"github.com/nutanix-cloud-native/prism-go-client/converged"
 	"github.com/nutanix-cloud-native/prism-go-client/internal/testhelpers"
 )
@@ -55,6 +56,42 @@ func TestAlertsIntegration(t *testing.T) {
 		assert.NoError(t, err)
 		assert.GreaterOrEqual(t, len(alerts), 0)
 	})
+
+	t.Run("ManageAlertAcknowledge", func(t *testing.T) {
+		// Discover a real alert and acknowledge it. Acknowledging is
+		// non-destructive (the alert is retained, just marked acknowledged).
+		alerts, err := client.Alerts.List(ctx, converged.WithLimit(1))
+		require.NoError(t, err)
+
+		if len(alerts) == 0 || alerts[0].ExtId == nil {
+			t.Skip("No alerts available for testing")
+		}
+
+		alertExtID := *alerts[0].ExtId
+		alert, err := client.Alerts.ManageAlert(ctx, alertExtID, converged.AlertActionAcknowledge)
+		assert.NoError(t, err)
+		assert.NotNil(t, alert)
+		if alert != nil {
+			assert.Equal(t, alertExtID, *alert.ExtId)
+		}
+	})
+
+	t.Run("ManageAlertAcknowledgeAsync", func(t *testing.T) {
+		alerts, err := client.Alerts.List(ctx, converged.WithLimit(1))
+		require.NoError(t, err)
+
+		if len(alerts) == 0 || alerts[0].ExtId == nil {
+			t.Skip("No alerts available for testing")
+		}
+
+		alertExtID := *alerts[0].ExtId
+		operation, err := client.Alerts.ManageAlertAsync(ctx, alertExtID, converged.AlertActionAcknowledge)
+		require.NoError(t, err)
+		require.NotNil(t, operation)
+
+		_, err = operation.Wait(ctx)
+		assert.NoError(t, err)
+	})
 }
 
 // TestAlertsService_ErrorHandling tests error handling for nil client.
@@ -78,5 +115,50 @@ func TestAlertsService_ErrorHandling(t *testing.T) {
 	t.Run("NewIterator_NilClient", func(t *testing.T) {
 		iterator := service.NewIterator(ctx)
 		assert.Nil(t, iterator)
+	})
+
+	t.Run("ManageAlert_NilClient", func(t *testing.T) {
+		_, err := service.ManageAlert(ctx, "test-id", converged.AlertActionAcknowledge)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "client is not initialized")
+	})
+
+	t.Run("ManageAlertAsync_NilClient", func(t *testing.T) {
+		_, err := service.ManageAlertAsync(ctx, "test-id", converged.AlertActionResolve)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "client is not initialized")
+	})
+}
+
+// TestAlertsService_ManageAlertValidation verifies that unsupported alert
+// actions are rejected before any API call is made. The client is built with
+// dummy credentials (no network calls happen at construction time), so the
+// action validation can be exercised deterministically without a live Prism.
+func TestAlertsService_ManageAlertValidation(t *testing.T) {
+	client, err := NewClient(prismgoclient.Credentials{
+		Endpoint: prismEndpointDummyValue,
+		Port:     "9440",
+		Username: "dummy",
+		Password: "dummy",
+		Insecure: true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	ctx := context.Background()
+	const unsupportedAction = converged.AlertAction("BOGUS")
+
+	t.Run("ManageAlertAsync_UnsupportedAction", func(t *testing.T) {
+		operation, err := client.Alerts.ManageAlertAsync(ctx, "test-id", unsupportedAction)
+		assert.Error(t, err)
+		assert.Nil(t, operation)
+		assert.Contains(t, err.Error(), "unsupported alert action")
+	})
+
+	t.Run("ManageAlert_UnsupportedAction", func(t *testing.T) {
+		alert, err := client.Alerts.ManageAlert(ctx, "test-id", unsupportedAction)
+		assert.Error(t, err)
+		assert.Nil(t, alert)
+		assert.Contains(t, err.Error(), "unsupported alert action")
 	})
 }

--- a/converged/v4/alerts_test.go
+++ b/converged/v4/alerts_test.go
@@ -49,10 +49,10 @@ func TestAlertsIntegration(t *testing.T) {
 	})
 
 	t.Run("ListAlertsWithFilter", func(t *testing.T) {
-		// Filter on unacknowledged alerts; an empty result is acceptable, the
-		// call must simply succeed and propagate the filter without error.
+		// Filter on a severity value; an empty result is acceptable, the call
+		// must simply succeed and propagate the filter without error.
 		alerts, err := client.Alerts.List(ctx, converged.WithFilter(
-			"acknowledged eq false"))
+			"severity eq Monitoring.Alert.AlertSeverity'kCritical'"))
 		assert.NoError(t, err)
 		assert.GreaterOrEqual(t, len(alerts), 0)
 	})

--- a/converged/v4/alerts_test.go
+++ b/converged/v4/alerts_test.go
@@ -49,10 +49,10 @@ func TestAlertsIntegration(t *testing.T) {
 	})
 
 	t.Run("ListAlertsWithFilter", func(t *testing.T) {
-		// Filter on a severity value; an empty result is acceptable, the call
-		// must simply succeed and propagate the filter without error.
+		// Filter on unacknowledged alerts; an empty result is acceptable, the
+		// call must simply succeed and propagate the filter without error.
 		alerts, err := client.Alerts.List(ctx, converged.WithFilter(
-			"severity eq Monitoring.Alert.AlertSeverity'kCritical'"))
+			"acknowledged eq false"))
 		assert.NoError(t, err)
 		assert.GreaterOrEqual(t, len(alerts), 0)
 	})


### PR DESCRIPTION
## Add converged-client Alert APIs

Following the existing service template, we add a new functionalities in the Alert APIs:

- `ManageAlert` , `ManageAlertAsync` 

These are wired through `converged.Client` generics and registered in `NewClientFromV4SDKClient`, backed by the v4 `AlertsServiceApi` instances. 

### Testing
- Unit tests for nil-client guards and option propagation (`alerts_test.go`)
- Tested the functionality on an existing Nutanix cluster
